### PR TITLE
Add environment variable to switch off user authorization by default.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,13 @@ listen: :8080
     #       development environment
     #   prod
     #       production environment
+    #   noauth
+    #       development environment with user authorization switched off
+    #       by default; MUST be removed once `Create Tenant administrator`
+    #       feature is fully implemented
     #
     # Defaults to: prod
-middleware: dev
+middleware: noauth
 
     # Private key path - used for JWT signing
     # Defaults to: /etc/useradm/rsa/private.pem

--- a/middleware.go
+++ b/middleware.go
@@ -27,8 +27,9 @@ import (
 )
 
 const (
-	EnvProd = "prod"
-	EnvDev  = "dev"
+	EnvProd   = "prod"
+	EnvDev    = "dev"
+	EnvNoAuth = "noauth"
 )
 
 var (
@@ -79,6 +80,9 @@ var (
 	middlewareMap = map[string][]rest.Middleware{
 		EnvProd: DefaultProdStack,
 		EnvDev:  DefaultDevStack,
+		// this is a temporary solution until work on user authentication is
+		// done and UI part is implemented
+		EnvNoAuth: DefaultDevStack,
 	}
 )
 
@@ -137,6 +141,13 @@ func SetupMiddleware(api *rest.Api, mwtype string, authorizer authz.Authorizer) 
 			"Link",
 		},
 	})
+
+	// TODO: remove below once user authentication is fully implemented
+	if mwtype == EnvNoAuth {
+		// do not use `AuthzMiddleware` and return immediately instead
+		l.Warn("running without authorization API and should not be used in production")
+		return nil
+	}
 
 	authzmw := &authz.AuthzMiddleware{
 		Authz:   authorizer,


### PR DESCRIPTION
To simplify integration testing we need to switch user authorization
by default. This should be removed once `Create Tenant administrator`
epic is finished.

Signed-off-by: Marcin Pasinski <marcin.pasinski@cfengine.com>