### PR TITLE
authz_simple: skip auth rules checking on POST /verify

### DIFF
--- a/authz_simple.go
+++ b/authz_simple.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	ResourceLogin       = "auth:login"
+	ResourceVerify      = "auth:verify"
 	ResourceInitialUser = "users:initial"
 )
 
@@ -34,6 +35,12 @@ type SimpleAuthz struct {
 func (sa *SimpleAuthz) Authorize(token *jwt.Token, resource, action string) error {
 	if token == nil {
 		return authz.ErrAuthzUnauthorized
+	}
+
+	// 'verify' is a special case - it will be called on all mgmt API calls in the system
+	// return immediately and let the target service handle authz
+	if resource == ResourceVerify {
+		return nil
 	}
 
 	// bypass checks for login

--- a/useradm.go
+++ b/useradm.go
@@ -169,6 +169,12 @@ func (ua *UserAdm) Verify(token *jwt.Token) error {
 		return ErrUnauthorized
 	}
 
+	// don't check the db if it's the initial user creation request
+	if token.Claims.Scope == ScopeInitialUserCreate &&
+		token.Claims.Subject == "initial" {
+		return nil
+	}
+
 	user, err := ua.db.GetUserById(token.Claims.Subject)
 	if user == nil && err == nil {
 		return ErrUnauthorized


### PR DESCRIPTION
this causes 403 errors on pretty much any management API call in the system.
note that all these requests are routed to /verify first - which subsequently
denies access since the authorizer tries to check the request against useradm's
own authz rules.

the quick solution is to make the authorizer aware of this, and return asap on POST /verify.
effectively, the actual authz will be delegated to the target downstream service;
useradm will only check the token validity, as it should.

also - skip checking the db on Verify() if it's the initial user creation request; we know there's no user, so the check will fail.

Issues: MEN-907

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@mendersoftware/rndity @maciejmrowiec 