### PR TITLE
authz_simple: correctly restrict actions for the 'mender.users.initia…

### DIFF
--- a/authz_simple_test.go
+++ b/authz_simple_test.go
@@ -69,6 +69,19 @@ func TestSimpleAuthzAuthorize(t *testing.T) {
 			},
 			outErr: "unauthorized",
 		},
+		"error: use 'mender.users.initial.create' with an incorrect resource/action": {
+			inResource: "foo:bar",
+			inAction:   "POST",
+			inToken: &jwt.Token{
+				Claims: jwt.Claims{
+					Issuer:    "mender",
+					ExpiresAt: 2147483647,
+					Subject:   "testsubject",
+					Scope:     ScopeInitialUserCreate,
+				},
+			},
+			outErr: "unauthorized",
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
…l.create' scope

this is the minimum effort fix for the permission escalation bug.
the culprit was the line which bypassed authz for the /verify endpoint - any valid
token was verified as authorized, regardless of scope - including the 'initial' token.

the scope is now restricted just by rearranging the conditional logic in the authorizer.
a more generic solution could be introduced by parsing the X-Original-URI header, and authorizing
based also on the target service. IMO however the authorization in general needs some more design,
esp. the 'centralized vs per-service' aspect, which is likely to cause further refactors; it makes sense
to wait with larger changes until then.

please see the JIRA comment for details.

Issues:  https://tracker.mender.io/browse/MEN-918

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>