### PR TITLE
explicitly use destination service name and action in authz rules

### DIFF
--- a/authz_simple.go
+++ b/authz_simple.go
@@ -20,9 +20,11 @@ import (
 )
 
 const (
-	ResourceLogin       = "auth:login"
-	ResourceVerify      = "auth:verify"
-	ResourceInitialUser = "users:initial"
+	ServiceName = "useradm"
+
+	ResourceLogin       = ServiceName + ":auth:login"
+	ResourceVerify      = ServiceName + ":auth:verify"
+	ResourceInitialUser = ServiceName + ":users:initial"
 )
 
 // SimpleAuthz is a trivial authorizer, mostly ensuring

--- a/authz_simple.go
+++ b/authz_simple.go
@@ -39,29 +39,18 @@ func (sa *SimpleAuthz) Authorize(token *jwt.Token, resource, action string) erro
 		return authz.ErrAuthzUnauthorized
 	}
 
-	// 'verify' is a special case - it will be called on all mgmt API calls in the system
-	// return immediately and let the target service handle authz
-	if resource == ResourceVerify {
-		return nil
-	}
-
-	// bypass checks for login
-	// for other resources - verify authz
-	if resource == ResourceLogin {
-		return nil
-	}
-
-	// check correct scope for initial user creation
 	scope := token.Claims.Scope
-	if scope == ScopeInitialUserCreate {
-		if action == "POST" && resource == ResourceInitialUser {
+
+	// restrict the 'initial token' to a single action
+	if action == "POST" && resource == ResourceInitialUser {
+		if scope == ScopeInitialUserCreate {
 			return nil
 		} else {
 			return authz.ErrAuthzUnauthorized
 		}
 	}
 
-	// allow all for 'mender.*'
+	// allow all actions on all services for 'mender.*'
 	if scope == ScopeAll {
 		return nil
 	}

--- a/authz_simple_test.go
+++ b/authz_simple_test.go
@@ -33,7 +33,7 @@ func TestSimpleAuthzAuthorize(t *testing.T) {
 		outErr string
 	}{
 		"ok - create init user with dedicated scope": {
-			inResource: "users:initial",
+			inResource: "useradm:users:initial",
 			inAction:   "POST",
 			inToken: &jwt.Token{
 				Claims: jwt.Claims{
@@ -44,8 +44,46 @@ func TestSimpleAuthzAuthorize(t *testing.T) {
 				},
 			},
 		},
-		"ok - do sth with the 'all' scope": {
-			inResource: "some:resource:id",
+		"error - use initial scope with incompatible useradm action": {
+			inResource: "useradm:some:resource:id",
+			inAction:   "POST",
+			inToken: &jwt.Token{
+				Claims: jwt.Claims{
+					Issuer:    "mender",
+					ExpiresAt: 2147483647,
+					Subject:   "testsubject",
+					Scope:     ScopeInitialUserCreate,
+				},
+			},
+			outErr: "unauthorized",
+		},
+		"error - use initial scope outside of useradm": {
+			inResource: "otherservice:some:resource:id",
+			inAction:   "POST",
+			inToken: &jwt.Token{
+				Claims: jwt.Claims{
+					Issuer:    "mender",
+					ExpiresAt: 2147483647,
+					Subject:   "testsubject",
+					Scope:     ScopeInitialUserCreate,
+				},
+			},
+			outErr: "unauthorized",
+		},
+		"ok - do sth in useradm with the 'all' scope": {
+			inResource: "useradm:some:resource:id",
+			inAction:   "POST",
+			inToken: &jwt.Token{
+				Claims: jwt.Claims{
+					Issuer:    "mender",
+					ExpiresAt: 2147483647,
+					Subject:   "testsubject",
+					Scope:     ScopeAll,
+				},
+			},
+		},
+		"ok - do sth in another service with the 'all' scope": {
+			inResource: "otherservice:some:resource:id",
 			inAction:   "POST",
 			inToken: &jwt.Token{
 				Claims: jwt.Claims{

--- a/middleware.go
+++ b/middleware.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -141,7 +142,7 @@ func SetupMiddleware(api *rest.Api, mwtype string, authorizer authz.Authorizer, 
 
 	authzmw := &authz.AuthzMiddleware{
 		Authz:      authorizer,
-		ResFunc:    extractResourceId,
+		ResFunc:    extractResourceAction,
 		JWTHandler: jwth,
 	}
 
@@ -163,12 +164,25 @@ func SetupMiddleware(api *rest.Api, mwtype string, authorizer authz.Authorizer, 
 	return nil
 }
 
-// extracts resource ID from the request url
-func extractResourceId(r *rest.Request) (string, error) {
-	//tokenize everything past the api version
-	path := r.URL.Path
+// extracts resource action from the request url
+func extractResourceAction(r *rest.Request) (*authz.Action, error) {
+	action := authz.Action{}
 
-	path = strings.Replace(path, uriBase, "", 1)
+	// extract original uri
+	uri := r.Header.Get("X-Original-URI")
+	uriItems := strings.Split(uri, "/")
 
-	return strings.Replace(path, "/", ":", 1), nil
+	if uri == "" || len(uriItems) < 4 {
+		return nil, errors.New("can't parse service name from original uri " + uri)
+	}
+
+	action.Resource = strings.Join(uriItems[4:], ":")
+
+	// extract original http method
+	action.Method = r.Header.Get("X-Original-Method")
+	if action.Method == "" {
+		return nil, errors.New("can't parse original request method")
+	}
+
+	return &action, nil
 }

--- a/middleware.go
+++ b/middleware.go
@@ -146,17 +146,16 @@ func SetupMiddleware(api *rest.Api, mwtype string, authorizer authz.Authorizer, 
 		JWTHandler: jwth,
 	}
 
-	//allow access without authz on /login
-	//all other enpoinds protected
+	//force authz only on /verify
 	ifmw := &rest.IfMiddleware{
 		Condition: func(r *rest.Request) bool {
-			if r.URL.Path == uriAuthLogin && r.Method == http.MethodPost {
+			if r.URL.Path == uriAuthVerify && r.Method == http.MethodPost {
 				return true
 			} else {
 				return false
 			}
 		},
-		IfFalse: authzmw,
+		IfTrue: authzmw,
 	}
 
 	api.Use(ifmw)


### PR DESCRIPTION
Issues: https://tracker.mender.io/browse/MEN-918

use the X-Original-URI and X-Original-Method headers to extract the *target* service name+http method and use these in authz checks. this clears up the bug in question, as well as makes the authz code more explicit and easier to reason about.

as a side note - a couple of thoughts on our authz middleware and authz infrastructure in general can be found in the jira comment section (basically, needs some decisions/refactoring, but post 1.0).

@mendersoftware/rndity @maciejmrowiec 