### PR TITLE
config.yaml: don't override the default 'prod middleware' setting

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,7 +10,7 @@ listen: :8080
     #       production environment
     #
     # Defaults to: prod
-middleware: dev
+# middleware: dev
 
     # Private key path - used for JWT signing
     # Defaults to: /etc/useradm/rsa/private.pem


### PR DESCRIPTION
the dev vs prod middleware is already set up correctly, and controlled
via the 'middleware' setting/'dev' flag (with prod as default). the only problem is the config file
which overrides this setting, and is pulled into the docker image - hence
the stack traces from RecoverMiddleware by default.

Issues: MEN-898

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>