### PR TITLE
travis: skip install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,8 @@ before_install:
     # Get our own Swagger verifier
     - wget https://raw.githubusercontent.com/mendersoftware/autodocs/master/verify_docs.py
 
+install: true
+
 before_script:
     # Print build info that binary is compiled with.
     - echo $TRAVIS_COMMIT


### PR DESCRIPTION
The default `install` step will run `go get -t ./...` which will fetch all
dependencies. A side effect is that dependencies that were not vendored will be
fetched. Overriding `install` step will allow the build/tests to fail, revealing
dependencies that are missing.

See https://docs.travis-ci.com/user/languages/go#Dependency-Management for
details.

Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>

@mendersoftware/rndity @maciejmrowiec 