### PR TITLE
MEN-963: Update API versioning.

### DIFF
--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -1,12 +1,12 @@
 swagger: '2.0'
 info:
-  version: '0.1'
+  version: '1'
   title: User administration and authentication
   description: |
     An API for user administration and user authentication handling. Intended for use by the web GUI.
 
-basePath: '/api/management/0.1/useradm'
-host: 'docker.mender.io:8080'
+basePath: '/api/management/v1/useradm'
+host: 'docker.mender.io'
 schemes:
   - https
 

--- a/middleware.go
+++ b/middleware.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ant0ine/go-json-rest/rest"
 	"github.com/mendersoftware/go-lib-micro/accesslog"
+	"github.com/mendersoftware/go-lib-micro/customheader"
 	dlog "github.com/mendersoftware/go-lib-micro/log"
 	"github.com/mendersoftware/go-lib-micro/requestid"
 	"github.com/mendersoftware/go-lib-micro/requestlog"
@@ -87,6 +88,11 @@ var (
 func SetupMiddleware(api *rest.Api, mwtype string, authorizer authz.Authorizer, jwth jwt.JWTHandler) error {
 
 	l := dlog.New(dlog.Ctx{})
+
+	api.Use(&customheader.CustomHeaderMiddleware{
+		HeaderName:  "X-USERADM-VERSION",
+		HeaderValue: CreateVersionString(),
+	})
 
 	l.Infof("setting up %s middleware", mwtype)
 

--- a/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware.go
+++ b/vendor/github.com/mendersoftware/go-lib-micro/customheader/middleware.go
@@ -1,0 +1,36 @@
+// Copyright 2016 Mender Software AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package customheader
+
+import "github.com/ant0ine/go-json-rest/rest"
+
+// Add custom HTTP header to all server responses
+type CustomHeaderMiddleware struct {
+	HeaderName  string
+	HeaderValue string
+}
+
+// MiddlewareFunc makes CustomHeaderMiddleware implement the Middleware interface.
+func (c *CustomHeaderMiddleware) MiddlewareFunc(h rest.HandlerFunc) rest.HandlerFunc {
+	return func(w rest.ResponseWriter, r *rest.Request) {
+
+		if len(c.HeaderName) > 0 {
+			w.Header().Add(c.HeaderName, c.HeaderValue)
+		}
+
+		// call the handler
+		h(w, r)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -122,6 +122,12 @@
 			"revisionTime": "2017-01-30T12:11:14Z"
 		},
 		{
+			"checksumSHA1": "5PDgQnNLCVPQR537rMBdiAPm5aM=",
+			"path": "github.com/mendersoftware/go-lib-micro/customheader",
+			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",
+			"revisionTime": "2017-01-30T12:11:14Z"
+		},
+		{
 			"checksumSHA1": "ARd+lex1hH+zfIYpSf3TYQkEOOc=",
 			"path": "github.com/mendersoftware/go-lib-micro/log",
 			"revision": "5a7f06d87cc653f59e4cd6de15e711d7b795bb46",


### PR DESCRIPTION
Change public routing to v1, v2, v3 schema (v1).
Update documentation.
Remove port 8080 from swagger.
Add service version header returned by API

Signed-off-by: Maciej Mrowiec <mrowiec.maciej@gmail.com>