### PR TITLE
travis: deploy useradm docs to site docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,9 @@ after_success:
     # Integrate with https://codecov.io
     - bash <(curl -s https://codecov.io/bash)
 
+    # Check if api docs have changed
+    - git show --stat ${TRAVIS_COMMIT_RANGE} | grep -E "docs/.+\.yml" && export API_DOCS_CHANGED=true
+
 before_deploy:
     # Master is always lastest
     - if [ ! -z "$TRAVIS_TAG" ]; then export IMAGE_TAG=$TRAVIS_TAG; else export IMAGE_TAG=$TRAVIS_BRANCH; fi
@@ -141,10 +144,11 @@ deploy:
         secret_access_key: $AWS_SECRET_ACCESS_KEY
         bucket: $AWS_BUCKET_DOCS
         region: $AWS_REGION
-        upload-dir: $TRAVIS_REPO_SLUG/latest/$TRAVIS_BRANCH
+        upload-dir: $DEPLOY_REPO/latest/$TRAVIS_BRANCH
         local_dir: docs
         skip_cleanup: true
         acl: public_read
         on:
-            repo: $TRAVIS_REPO_SLUG
+            repo: $DEPLOY_REPO
             all_branches: true
+            condition: $API_DOCS_CHANGED = true


### PR DESCRIPTION
supposedly, this magic will make useradm's swagger appear in the docs site.
goes with https://github.com/mendersoftware/mender-docs/pull/100
Issues: MEN-976

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>