### PR TITLE
create-user cli fixes (MT)

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/mendersoftware/go-lib-micro/config"
+	"github.com/mendersoftware/go-lib-micro/identity"
 	"github.com/mendersoftware/go-lib-micro/log"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh/terminal"
@@ -47,7 +48,7 @@ func safeReadPassword() (string, error) {
 	return string(raw), nil
 }
 
-func commandCreateUser(c config.Reader, username string, password string, userId string) error {
+func commandCreateUser(c config.Reader, username, password, userId, tenantId string) error {
 	l := log.NewEmpty()
 
 	l.Debugf("create user '%s'", username)
@@ -79,9 +80,23 @@ func commandCreateUser(c config.Reader, username string, password string, userId
 
 	ua := useradm.NewUserAdm(nil, db, useradm.Config{})
 
-	if err := ua.CreateUser(context.Background(), &u); err != nil {
+	ctx := getTenantContext(tenantId)
+	if err := ua.CreateUser(ctx, &u); err != nil {
 		return errors.Wrap(err, "creating user failed")
 	}
 
 	return nil
+}
+
+func getTenantContext(tenantId string) context.Context {
+	ctx := context.Background()
+	if tenantId != "" {
+		id := &identity.Identity{
+			Tenant: tenantId,
+		}
+
+		ctx = identity.WithContext(ctx, id)
+	}
+
+	return ctx
 }

--- a/commands.go
+++ b/commands.go
@@ -47,7 +47,7 @@ func safeReadPassword() (string, error) {
 	return string(raw), nil
 }
 
-func commandCreateUser(c config.Reader, username string, password string) error {
+func commandCreateUser(c config.Reader, username string, password string, userId string) error {
 	l := log.NewEmpty()
 
 	l.Debugf("create user '%s'", username)
@@ -62,6 +62,10 @@ func commandCreateUser(c config.Reader, username string, password string) error 
 	u := model.User{
 		Email:    username,
 		Password: password,
+	}
+
+	if userId != "" {
+		u.ID = userId
 	}
 
 	if err := u.ValidateNew(); err != nil {

--- a/commands_test.go
+++ b/commands_test.go
@@ -29,11 +29,11 @@ func TestCommandCreateUser(t *testing.T) {
 	conf.On("GetString", SettingDbPassword).Return("haha")
 
 	// not an email, password too short
-	err := commandCreateUser(conf, "foo", "bar")
+	err := commandCreateUser(conf, "foo", "bar", "")
 	assert.Error(t, err)
 
 	if !testing.Short() {
-		err = commandCreateUser(conf, "foo@bar.com", "foobarbarbar")
+		err = commandCreateUser(conf, "foo@bar.com", "foobarbarbar", "")
 		assert.Error(t, err)
 	}
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -29,11 +29,11 @@ func TestCommandCreateUser(t *testing.T) {
 	conf.On("GetString", SettingDbPassword).Return("haha")
 
 	// not an email, password too short
-	err := commandCreateUser(conf, "foo", "bar", "")
+	err := commandCreateUser(conf, "foo", "bar", "", "")
 	assert.Error(t, err)
 
 	if !testing.Short() {
-		err = commandCreateUser(conf, "foo@bar.com", "foobarbarbar", "")
+		err = commandCreateUser(conf, "foo@bar.com", "foobarbarbar", "", "")
 		assert.Error(t, err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -74,6 +74,10 @@ func doMain(args []string) {
 					Name:  "user-id",
 					Usage: "User ID, if already generated/available (optional).",
 				},
+				cli.StringFlag{
+					Name:  "tenant-id",
+					Usage: "Tenant ID, if running a multitenant setup (optional).",
+				},
 			},
 			Action: runCreateUser,
 		},
@@ -136,7 +140,7 @@ func runDeamon(args *cli.Context) error {
 
 func runCreateUser(args *cli.Context) error {
 	err := commandCreateUser(config.Config,
-		args.String("username"), args.String("password"), args.String("user-id"))
+		args.String("username"), args.String("password"), args.String("user-id"), args.String("tenant-id"))
 	if err != nil {
 		return cli.NewExitError(err.Error(), 5)
 	}

--- a/main.go
+++ b/main.go
@@ -70,6 +70,10 @@ func doMain(args []string) {
 					Name:  "password",
 					Usage: "User's password, leave empty to have it read from stdin",
 				},
+				cli.StringFlag{
+					Name:  "user-id",
+					Usage: "User ID, if already generated/available (optional).",
+				},
 			},
 			Action: runCreateUser,
 		},
@@ -132,7 +136,7 @@ func runDeamon(args *cli.Context) error {
 
 func runCreateUser(args *cli.Context) error {
 	err := commandCreateUser(config.Config,
-		args.String("username"), args.String("password"))
+		args.String("username"), args.String("password"), args.String("user-id"))
 	if err != nil {
 		return cli.NewExitError(err.Error(), 5)
 	}

--- a/user/useradm.go
+++ b/user/useradm.go
@@ -139,7 +139,9 @@ func (u *UserAdm) SignToken(ctx context.Context, t *jwt.Token) (string, error) {
 }
 
 func (ua *UserAdm) CreateUser(ctx context.Context, u *model.User) error {
-	u.ID = uuid.NewV4().String()
+	if u.ID == "" {
+		u.ID = uuid.NewV4().String()
+	}
 
 	if err := ua.db.CreateUser(ctx, u); err != nil {
 		if err == store.ErrDuplicateEmail {


### PR DESCRIPTION
Issues: MEN-1256

make the `create-user` cli multitenant-aware by accepting a `--tenant-id`.
also, allow the user to set `--user-id`

@maciejmrowiec @mendersoftware/rndity 