### PR TITLE
user: correctly prepare context with tenant id at Login

### DIFF
--- a/user/useradm.go
+++ b/user/useradm.go
@@ -84,7 +84,8 @@ func NewUserAdm(jwtHandler jwt.Handler, db store.DataStore, config Config) *User
 }
 
 func (u *UserAdm) Login(ctx context.Context, email, pass string) (*jwt.Token, error) {
-	var tenantClaim string
+	var ident identity.Identity
+
 	if u.verifyTenant {
 		// check the user's tenant
 		tenant, err := u.cTenant.GetTenant(ctx, email, u.clientGetter())
@@ -97,7 +98,8 @@ func (u *UserAdm) Login(ctx context.Context, email, pass string) (*jwt.Token, er
 			return nil, ErrUnauthorized
 		}
 
-		tenantClaim = tenant.ID
+		ident.Tenant = tenant.ID
+		ctx = identity.WithContext(ctx, &ident)
 	}
 
 	//get user
@@ -117,7 +119,7 @@ func (u *UserAdm) Login(ctx context.Context, email, pass string) (*jwt.Token, er
 	}
 
 	//generate token
-	t := u.generateToken(user.ID, scope.All, tenantClaim)
+	t := u.generateToken(user.ID, scope.All, ident.Tenant)
 
 	return t, nil
 }

--- a/user/useradm_test.go
+++ b/user/useradm_test.go
@@ -228,12 +228,12 @@ func TestUserAdmLogin(t *testing.T) {
 		ctx := context.Background()
 
 		db := &mstore.DataStore{}
-		db.On("GetUserByEmail", ctx, tc.inEmail).Return(tc.dbUser, tc.dbUserErr)
+		db.On("GetUserByEmail", ContextMatcher(), tc.inEmail).Return(tc.dbUser, tc.dbUserErr)
 
 		useradm := NewUserAdm(nil, db, tc.config)
 		if tc.verifyTenant {
 			cTenant := &mct.ClientRunner{}
-			cTenant.On("GetTenant", ctx, tc.inEmail, &apiclient.HttpApi{}).
+			cTenant.On("GetTenant", ContextMatcher(), tc.inEmail, &apiclient.HttpApi{}).
 				Return(tc.tenant, tc.tenantErr)
 			useradm = useradm.WithTenantVerification(cTenant)
 		}


### PR DESCRIPTION
the tenant's identity was never added into the context, so
the data layer could not select the db correctly (DbFromContext).
this caused failures at login in mutitenant scenarios.

Issues: MEN-1312

Changelog: None

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

@maciejmrowiec @mendersoftware/rndity 