### PR TITLE
fix multitenant acceptance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ script:
         go build ;
         ./tests/build-acceptance ./tests ./docs/internal_api.yml ./docs/management_api.yml useradm;
 
-        TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance.yml ;
+        TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance.yml && TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance-multitenant.yml;
       fi
 
 after_success:

--- a/client/tenant/client_tenantadm.go
+++ b/client/tenant/client_tenantadm.go
@@ -64,14 +64,14 @@ type Client struct {
 
 // Tenant is the tenantadm's api struct
 type Tenant struct {
-	ID   string
-	Name string
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // User is the tenantadm's api struct
 type User struct {
-	ID       string
-	Name     string
+	ID       string `json:"id"`
+	Name     string `json:"name"`
 	TenantID string `json:"tenant_id"`
 }
 

--- a/tests/docker-compose-acceptance-multitenant.yml
+++ b/tests/docker-compose-acceptance-multitenant.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+    acceptance:
+        image: testing
+        networks:
+            - mender
+        volumes:
+            - "${TESTS_DIR}:/testing"
+        depends_on:
+            - mender-useradm
+        # run multi tenant tests only
+        command: -k Multitenant
+        environment:
+            FAKE_TENANTADM_ADDR: "0.0.0.0:9997"
+    mender-useradm:
+        image: mendersoftware/useradm:prtest
+        networks:
+            - mender
+        depends_on:
+            - mender-mongo-useradm
+        volumes:
+            - "${TESTS_DIR}:/testing"
+        environment:
+            # acceptance container will be running mocks for a couple of
+            # services, direct deviceauth there
+            USERADM_TENANTADM_ADDR: "http://acceptance:9997"

--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -8,8 +8,7 @@ services:
             - "${TESTS_DIR}:/testing"
         depends_on:
             - mender-useradm
-        environment:
-            FAKE_TENANTADM_ADDR: "0.0.0.0:9997"
+        command: -k 'not Multitenant'
     mender-useradm:
         image: mendersoftware/useradm:prtest
         networks:
@@ -18,7 +17,3 @@ services:
             - mender-mongo-useradm
         volumes:
             - "${TESTS_DIR}:/testing"
-        environment:
-            # acceptance container will be running mocks for a couple of
-            # services, direct deviceauth there
-            USERADM_TENANT_ADM_ADDR: "http://acceptance:9997"

--- a/tests/tests/tenantadm.py
+++ b/tests/tests/tenantadm.py
@@ -22,3 +22,21 @@ import mockserver
 
 def get_fake_tenantadm_addr():
     return os.environ.get('FAKE_TENANTADM_ADDR', '0.0.0.0:9997')
+
+def fake_create_user(user, status):
+    def create_user(request):
+        req_user = json.loads(request.body.decode())
+        assert req_user["name"] == user["email"]
+        return (status, {}, '')
+
+    return create_user
+
+@contextmanager
+def run_fake_create_user(user, status=201):
+    handlers = [
+            ('POST', '/api/internal/v1/tenantadm/users', fake_create_user(user, status))
+        ]
+
+    with mockserver.run_fake(get_fake_tenantadm_addr(),
+                             handlers=handlers) as server:
+        yield server

--- a/tests/tests/test_api_management.py
+++ b/tests/tests/test_api_management.py
@@ -89,7 +89,7 @@ class TestManagementApiPostUsers(TestManagementApiPostUsersBase):
         self._do_test_fail_duplicate_email(api_client_mgmt, init_users)
 
 
-class TestManagementApiPostUsersMultitenant(TestManagementApiPostUsers):
+class TestManagementApiPostUsersMultitenant(TestManagementApiPostUsersBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, tenant_id, api_client_mgmt, init_users_mt):
         self._do_test_ok(api_client_mgmt, init_users_mt[tenant_id], tenant_id)

--- a/tests/tests/test_api_management.py
+++ b/tests/tests/test_api_management.py
@@ -15,14 +15,14 @@
 from common import init_users, init_users_mt, cli,api_client_mgmt, mongo, make_auth
 import bravado
 import pytest
+import tenantadm
 
 class TestManagementApiPostUsersBase:
-    def _do_test_ok(self, api_client_mgmt, init_users, tenant_id=None):
+    def _do_test_ok(self, api_client_mgmt, init_users, new_user, tenant_id=None):
         auth=None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
-        new_user = {"email":"foo@bar.com", "password": "asdf1234zxcv"}
 
         _, r = api_client_mgmt.create_user(new_user, auth)
         assert r.status_code == 201
@@ -34,12 +34,11 @@ class TestManagementApiPostUsersBase:
         assert len(found_user) == 1
         found_user = found_user[0]
 
-    def _do_test_fail_duplicate_email(self, api_client_mgmt, init_users, tenant_id=None):
+    def _do_test_fail_duplicate_email(self, api_client_mgmt, init_users, new_user, tenant_id=None):
         auth=None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
-        new_user = {"email":init_users[0].email, "password": "asdf1234zxcv"}
         try:
             api_client_mgmt.create_user(new_user, auth)
         except bravado.exception.HTTPError as e:
@@ -48,7 +47,8 @@ class TestManagementApiPostUsersBase:
 
 class TestManagementApiPostUsers(TestManagementApiPostUsersBase):
     def test_ok(self, api_client_mgmt, init_users):
-        self._do_test_ok(api_client_mgmt, init_users)
+        new_user = {"email":"foo@bar.com", "password": "asdf1234zxcv"}
+        self._do_test_ok(api_client_mgmt, init_users, new_user)
 
     def test_fail_malformed_body(self, api_client_mgmt):
         new_user = {"foo":"bar"}
@@ -86,14 +86,19 @@ class TestManagementApiPostUsers(TestManagementApiPostUsersBase):
             assert e.response.status_code == 422
 
     def test_fail_duplicate_email(self, api_client_mgmt, init_users):
-        self._do_test_fail_duplicate_email(api_client_mgmt, init_users)
+        new_user = {"email":"foo@bar.com", "password": "asdf"}
+        self._do_test_fail_duplicate_email(api_client_mgmt, init_users, new_user)
 
 
 class TestManagementApiPostUsersMultitenant(TestManagementApiPostUsersBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, tenant_id, api_client_mgmt, init_users_mt):
-        self._do_test_ok(api_client_mgmt, init_users_mt[tenant_id], tenant_id)
+        new_user = {"email":"foo@bar.com", "password": "asdf1234zxcv"}
+        with tenantadm.run_fake_create_user(new_user):
+            self._do_test_ok(api_client_mgmt, init_users_mt[tenant_id], new_user, tenant_id)
 
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_fail_duplicate_email(self, tenant_id, api_client_mgmt, init_users_mt):
-        self._do_test_fail_duplicate_email(api_client_mgmt, init_users_mt[tenant_id], tenant_id)
+        new_user = {"email":"foo@bar.com", "password": "asdf1234zxcv"}
+        with tenantadm.run_fake_create_user(new_user, 422):
+            self._do_test_fail_duplicate_email(api_client_mgmt, init_users_mt[tenant_id], new_user, tenant_id)


### PR DESCRIPTION
this fixes several issues I bumped upon during MEN-1284.

multitenancy was never properly enabled because of a mistake in the tenantadm address env; the tests were effectively single-tenant.

otoh the fake tenantadm was never started even for MT-tests, so to put it shortly, everything was wrong on many levels.

this PR:
- sets up correct single-tenant and multi-tenant compose files
- runs them both in travis
- implements a fake tenantadm create-user handler, and runs it in MT tests
- fixes a json encoding bug in `useradm` itself (invalid field names in `tenantadm` requests)