### PR TITLE
client/tenant: fix json names of tenantadm's api structs

### DIFF
--- a/client/tenant/client_tenantadm.go
+++ b/client/tenant/client_tenantadm.go
@@ -64,14 +64,14 @@ type Client struct {
 
 // Tenant is the tenantadm's api struct
 type Tenant struct {
-	ID   string
-	Name string
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 // User is the tenantadm's api struct
 type User struct {
-	ID       string
-	Name     string
+	ID       string `json:"id"`
+	Name     string `json:"name"`
 	TenantID string `json:"tenant_id"`
 }
 


### PR DESCRIPTION
It was incorrectly assumed that these will be encoded to lowercase
by default.