### PR TITLE
align URLs

### DIFF
--- a/api/http/api_useradm.go
+++ b/api/http/api_useradm.go
@@ -30,11 +30,11 @@ import (
 )
 
 const (
-	uriBase       = "/api/0.1.0/"
-	uriAuthLogin  = uriBase + "auth/login"
-	uriAuthVerify = uriBase + "auth/verify"
-	uriUser       = uriBase + "users/:id"
-	uriUsers      = uriBase + "users"
+	uriManagementAuthLogin = "/api/management/v1/useradm/auth/login"
+	uriManagementUser      = "/api/management/v1/useradm/users/:id"
+	uriManagementUsers     = "/api/management/v1/useradm/users"
+
+	uriInternalAuthVerify = "/api/internal/v1/useradm/auth/verify"
 )
 
 var (
@@ -55,13 +55,14 @@ func NewUserAdmApiHandlers(userAdm useradm.App) ApiHandler {
 
 func (i *UserAdmApiHandlers) GetApp() (rest.App, error) {
 	routes := []*rest.Route{
-		rest.Post(uriAuthLogin, i.AuthLoginHandler),
-		rest.Post(uriAuthVerify, i.AuthVerifyHandler),
-		rest.Post(uriUsers, i.AddUserHandler),
-		rest.Get(uriUsers, i.GetUsersHandler),
-		rest.Get(uriUser, i.GetUserHandler),
-		rest.Put(uriUser, i.UpdateUserHandler),
-		rest.Delete(uriUser, i.DeleteUserHandler),
+		rest.Post(uriInternalAuthVerify, i.AuthVerifyHandler),
+
+		rest.Post(uriManagementAuthLogin, i.AuthLoginHandler),
+		rest.Post(uriManagementUsers, i.AddUserHandler),
+		rest.Get(uriManagementUsers, i.GetUsersHandler),
+		rest.Get(uriManagementUser, i.GetUserHandler),
+		rest.Put(uriManagementUser, i.UpdateUserHandler),
+		rest.Delete(uriManagementUser, i.DeleteUserHandler),
 	}
 
 	routes = append(routes)

--- a/api/http/api_useradm_test.go
+++ b/api/http/api_useradm_test.go
@@ -144,7 +144,8 @@ func TestUserAdmApiLogin(t *testing.T) {
 		uadm.On("SignToken", ctx, tc.uaToken).Return(tc.signed, tc.signErr)
 
 		//make mock request
-		req := makeReq("POST", "http://1.2.3.4/api/0.1.0/auth/login", tc.inAuthHeader, nil)
+		req := makeReq("POST", "http://1.2.3.4/api/management/v1/useradm/auth/login",
+			tc.inAuthHeader, nil)
 
 		api := makeMockApiHandler(t, uadm)
 
@@ -166,7 +167,7 @@ func TestCreateUser(t *testing.T) {
 	}{
 		"ok": {
 			inReq: test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/users",
+				"http://1.2.3.4/api/management/v1/useradm/users",
 				map[string]interface{}{
 					"email":    "foo@foo.com",
 					"password": "foobarbar",
@@ -181,7 +182,7 @@ func TestCreateUser(t *testing.T) {
 		},
 		"password too short": {
 			inReq: test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/users",
+				"http://1.2.3.4/api/management/v1/useradm/users",
 				map[string]interface{}{
 					"email":    "foo@foo.com",
 					"password": "foobar",
@@ -196,7 +197,7 @@ func TestCreateUser(t *testing.T) {
 		},
 		"duplicated email": {
 			inReq: test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/users",
+				"http://1.2.3.4/api/management/v1/useradm/users",
 				map[string]interface{}{
 					"email":    "foo@foo.com",
 					"password": "foobarbar",
@@ -212,7 +213,7 @@ func TestCreateUser(t *testing.T) {
 		},
 		"no body": {
 			inReq: test.MakeSimpleRequest("POST",
-				"http://1.2.3.4/api/0.1.0/users", nil),
+				"http://1.2.3.4/api/management/v1/useradm/users", nil),
 
 			checker: mt.NewJSONResponse(
 				http.StatusBadRequest,
@@ -253,7 +254,7 @@ func TestUpdateUser(t *testing.T) {
 	}{
 		"ok": {
 			inReq: test.MakeSimpleRequest("PUT",
-				"http://1.2.3.4/api/0.1.0/users/123",
+				"http://1.2.3.4/api/management/v1/useradm/users/123",
 				map[string]interface{}{
 					"email":    "foo@foo.com",
 					"password": "foobarbar",
@@ -268,7 +269,7 @@ func TestUpdateUser(t *testing.T) {
 		},
 		"password too short": {
 			inReq: test.MakeSimpleRequest("PUT",
-				"http://1.2.3.4/api/0.1.0/users/123",
+				"http://1.2.3.4/api/management/v1/useradm/users/123",
 				map[string]interface{}{
 					"password": "foobar",
 				},
@@ -282,7 +283,7 @@ func TestUpdateUser(t *testing.T) {
 		},
 		"duplicated email": {
 			inReq: test.MakeSimpleRequest("PUT",
-				"http://1.2.3.4/api/0.1.0/users/123",
+				"http://1.2.3.4/api/management/v1/useradm/users/123",
 				map[string]interface{}{
 					"email": "foo@foo.com",
 				},
@@ -297,7 +298,7 @@ func TestUpdateUser(t *testing.T) {
 		},
 		"no body": {
 			inReq: test.MakeSimpleRequest("PUT",
-				"http://1.2.3.4/api/0.1.0/users/123", nil),
+				"http://1.2.3.4/api/management/v1/useradm/users/123", nil),
 
 			checker: mt.NewJSONResponse(
 				http.StatusBadRequest,
@@ -307,7 +308,7 @@ func TestUpdateUser(t *testing.T) {
 		},
 		"incorrect body": {
 			inReq: test.MakeSimpleRequest("PUT",
-				"http://1.2.3.4/api/0.1.0/users/123",
+				"http://1.2.3.4/api/management/v1/useradm/users/123",
 				map[string]interface{}{
 					"id": "1234",
 				}),
@@ -465,7 +466,7 @@ func TestUserAdmApiPostVerify(t *testing.T) {
 
 		//make request
 		req := makeReq("POST",
-			"http://1.2.3.4/api/0.1.0/auth/verify",
+			"http://1.2.3.4/api/internal/v1/useradm/auth/verify",
 			"Bearer "+token,
 			nil)
 
@@ -571,7 +572,7 @@ func TestUserAdmApiGetUsers(t *testing.T) {
 
 			//make request
 			req := makeReq("GET",
-				"http://1.2.3.4/api/0.1.0/users",
+				"http://1.2.3.4/api/management/v1/useradm/users",
 				"Bearer "+token,
 				nil)
 
@@ -662,7 +663,7 @@ func TestUserAdmApiGetUser(t *testing.T) {
 
 			//make request
 			req := makeReq("GET",
-				"http://1.2.3.4/api/0.1.0/users/foo",
+				"http://1.2.3.4/api/management/v1/useradm/users/foo",
 				"Bearer "+token,
 				nil)
 
@@ -729,7 +730,7 @@ func TestUserAdmApiDeleteUser(t *testing.T) {
 
 			//make request
 			req := makeReq("DELETE",
-				"http://1.2.3.4/api/0.1.0/users/foo",
+				"http://1.2.3.4/api/management/v1/useradm/users/foo",
 				"Bearer "+token,
 				nil)
 

--- a/api/http/middleware.go
+++ b/api/http/middleware.go
@@ -24,7 +24,7 @@ import (
 )
 
 func IsVerificationEndpoint(r *rest.Request) bool {
-	if r.URL.Path == uriAuthVerify && r.Method == http.MethodPost {
+	if r.URL.Path == uriInternalAuthVerify && r.Method == http.MethodPost {
 		return true
 	} else {
 		return false

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -5,7 +5,7 @@ info:
   description: |
     An API for user administration and user authentication handling. Not exposed via the API Gateway - intended for internal use only.
 
-basePath: '/api/0.1.0/'
+basePath: '/api/internal/v1/useradm'
 host: 'mender-device-auth:8080'
 schemes:
   - http

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -58,6 +58,8 @@ class ApiClient:
 class InternalApiClient(ApiClient):
     log = logging.getLogger('client.InternalClient')
     spec_option = 'internal_spec'
+    api_url = "http://%s/api/internal/v1/useradm/" % \
+              pytest.config.getoption("host")
 
     def __init__(self):
         super().__init__()
@@ -75,6 +77,8 @@ class InternalApiClient(ApiClient):
 class ManagementApiClient(ApiClient):
     log = logging.getLogger('client.ManagementClient')
     spec_option = 'management_spec'
+    api_url = "http://%s/api/management/v1/useradm/" % \
+              pytest.config.getoption("host")
 
     # default user auth - single user, single tenant
     auth = {"Authorization": "Bearer foobarbaz"}


### PR DESCRIPTION
@mendersoftware/rndity 

needs to go with https://github.com/mendersoftware/mender-api-gateway-docker/pull/78

The change is needed so that we can selectively expose only management endpoints on the gateway. Otherwise, if we add a tenant endpoint now, it will still be possible to access it through the gateway with a specially crafted URL.