### PR TITLE
Recover from unsuccessful attempt to create user

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -51,7 +51,7 @@ def make_basic_auth(username, password):
 
 @pytest.fixture(scope="session")
 def mongo():
-    return MongoClient('mender-mongo-useradm:27017')
+    return MongoClient('mender-mongo:27017')
 
 def mongo_cleanup(mongo):
     dbs = mongo.database_names()

--- a/tests/docker-compose-acceptance-multitenant.yml
+++ b/tests/docker-compose-acceptance-multitenant.yml
@@ -17,7 +17,7 @@ services:
         networks:
             - mender
         depends_on:
-            - mender-mongo-useradm
+            - mender-mongo
         volumes:
             - "${TESTS_DIR}:/testing"
         environment:

--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -14,7 +14,7 @@ services:
         networks:
             - mender
         depends_on:
-            - mender-mongo-useradm
+            - mender-mongo
         volumes:
             - "${TESTS_DIR}:/testing"
         environment:


### PR DESCRIPTION
Issues: https://tracker.mender.io/browse/MEN-1950

There are two cases:
- if writing user to usearadm database failed, try to remove previously created user from tenantadm;
- if tenantadm reports that the user already exists, but it does not exist in the useradm database, try to remove the user from tenantadm;