### PR TITLE
travis: run backend integration tests    

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,14 @@ addons:
       - mongodb-3.4-precise
     packages:
       - mongodb-org-server
+      - "python3"
+      - "python3-pip"
 
 # Golang version matrix
 go:
     - 1.8
 
 env:
-    matrix:
-        - JOB_TYPE=compile_and_basic_tests
-        - JOB_TYPE=acceptance_tests
-        - JOB_TYPE=backend_integration_tests
-
     global:
         # Should be encrypted or set as private travis variables (in travis settings):
         # AWS_ACCESS_KEY_ID
@@ -44,25 +41,134 @@ env:
         # Use correct branch for testing
         - TEST_BRANCH=$TRAVIS_BRANCH
 
-before_install:
-
-    # Install code coverage tooling
-    - go get -u github.com/axw/gocov/gocov
-    - go get -u golang.org/x/tools/cmd/cover
-
-    # Install cyclomatic dependency analysis tool
-    - go get -u github.com/fzipp/gocyclo
-
-    - sudo apt-get -qq update
-    - sudo apt-get -qq install -y e2tools
-    - npm install -g swagger-cli
-
-    - pip2.7 install -U --user paramiko fabric PyYAML pytest requests pytest-xdist filelock
-
-    # Get our own Swagger verifier
-    - wget https://raw.githubusercontent.com/mendersoftware/autodocs/master/verify_docs.py
 
 install: true
+
+jobs:
+    include:
+    - stage: Static code checks
+      install:
+        - sudo apt-get -qq update
+        # Install code coverage tooling
+        - go get -u github.com/axw/gocov/gocov
+        - go get -u golang.org/x/tools/cmd/cover
+
+        # Install cyclomatic dependency analysis tool
+        - go get -u github.com/fzipp/gocyclo
+
+        - sudo apt-get -qq install -y e2tools
+        - npm install -g swagger-cli
+
+        # Get our own Swagger verifier
+        - wget https://raw.githubusercontent.com/mendersoftware/autodocs/master/verify_docs.py
+
+      script:
+        # Rename the branch we're on, so that it's not in the way for the
+        # subsequent fetch. It's ok if this fails, it just means we're not on any
+        # branch.
+        - git branch -m temp-branch || true
+        # Git trick: Fetch directly into our local branches instead of remote
+        # branches.
+        - git fetch origin 'refs/heads/*:refs/heads/*'
+        # Get last remaining tags, if any.
+        - git fetch --tags origin
+
+        # Test if code was formatted with 'go fmt'
+        # Command will format code and return modified files
+        # fail if any have been modified.
+        - if [ -n "$(go fmt)" ]; then echo 'Code is not formatted with "go fmt"'; false; fi
+
+        # Perform static code analysys
+        - go vet `go list ./... | grep -v vendor`
+
+        # Fail builds when the cyclomatic complexity reaches 15 or more
+        - gocyclo -over 15 `find . -iname '*.go' | grep -v 'vendor' | grep -v '_test.go'`
+
+        # Verify that the Swagger docs are valid
+        - swagger-cli validate docs/*.yml
+
+        # Verify that the Swagger docs follow the autodeployment requirements
+        - if test "$(ls -A docs)"; then python2.7 verify_docs.py `find docs -name "*.yml"`; fi
+    - stage: Tests
+      name: "unit"
+      install: skip
+      script:
+        - go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $? ;
+
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -F unittests ;
+    - stage: Tests
+      name: "acceptance"
+      install: skip
+      script:
+        - git clone -b master https://github.com/mendersoftware/integration.git;
+        - mv integration/extra/travis-testing/* tests/ ;
+
+        - CGO_ENABLED=0 go test -c -o useradm-test -coverpkg $(go list ./... | grep -v vendor | grep -v mocks | grep -v test | tr  '\n' ,);
+
+        - sudo docker build -f Dockerfile.acceptance-testing -t mendersoftware/useradm:prtest .;
+
+        - go build ;
+        - ./tests/build-acceptance ./tests ./docs/internal_api.yml ./docs/management_api.yml useradm;
+
+        - TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance.yml && TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance-multitenant.yml;
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -F acceptance -f ./tests/coverage-acceptance.txt;
+    - stage: Tests
+      name: "backend-integration"
+      install:
+        - sudo apt-get -qq update
+        - pip3 install -U --user PyYAML
+      script:
+        - git clone -b master https://github.com/mendersoftware/integration.git;
+
+        - CGO_ENABLED=0 go build;
+        - sudo docker build -t mendersoftware/useradm:pr .;
+
+        - ./integration/extra/release_tool.py --set-version-of mender-useradm --version pr;
+        - ./integration/backend-tests/run;
+    - stage: Build and publish
+      name: "dockerhub"
+      install: skip
+      before_deploy:
+        - CGO_ENABLED=0 go build -ldflags "-X main.Commit=`echo $TRAVIS_COMMIT` -X main.Tag=`echo $TRAVIS_TAG` -X main.Branch=`echo $TRAVIS_BRANCH` -X main.BuildNumber=`echo $TRAVIS_BUILD_NUMBER`" ;
+        - sudo docker build -t $DOCKER_REPOSITORY:pr . ;
+        - if [ ! -z "$TRAVIS_TAG" ]; then export IMAGE_TAG=$TRAVIS_TAG; else export IMAGE_TAG=$TRAVIS_BRANCH; fi ;
+        - docker tag $DOCKER_REPOSITORY:pr $DOCKER_REPOSITORY:$IMAGE_TAG ;
+        - docker login --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD ;
+        - docker push $DOCKER_REPOSITORY:$IMAGE_TAG ;
+
+        - if [ "$TRAVIS_BRANCH" = master ]; then
+            export COMMIT_TAG="$TRAVIS_BRANCH"_"$TRAVIS_COMMIT";
+            docker tag $DOCKER_REPOSITORY:pr $DOCKER_REPOSITORY:$COMMIT_TAG;
+            docker push $DOCKER_REPOSITORY:$COMMIT_TAG;
+          fi;
+      # dummy deploy just to get the 'before_deploy' running
+      deploy:
+        -
+          provider: script
+          script: /bin/true
+    - stage: Build and publish
+      name: "docs"
+      install: skip
+      script: skip
+      deploy:
+        -
+          provider: s3
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: $AWS_BUCKET_DOCS
+          region: $AWS_REGION
+          upload-dir: $TRAVIS_REPO_SLUG/latest/$TRAVIS_BRANCH
+          local_dir: docs
+          skip_cleanup: true
+          acl: public_read
+          on:
+            repo: $TRAVIS_REPO_SLUG
+            all_branches: true
+    - stage: Trigger integration
+      script:
+        - echo "TODO trigger jenkins integration tests"
 
 before_script:
     # Print build info that binary is compiled with.
@@ -71,113 +177,3 @@ before_script:
     - echo $TRAVIS_BRANCH
     - echo $TRAVIS_BUILD_NUMBER
     - echo $TRAVIS_REPO_SLUG
-
-    # Rename the branch we're on, so that it's not in the way for the
-    # subsequent fetch. It's ok if this fails, it just means we're not on any
-    # branch.
-    - git branch -m temp-branch || true
-    # Git trick: Fetch directly into our local branches instead of remote
-    # branches.
-    - git fetch origin 'refs/heads/*:refs/heads/*'
-    # Get last remaining tags, if any.
-    - git fetch --tags origin
-
-    # Test if code was formatted with 'go fmt'
-    # Command will format code and return modified files
-    # fail if any have been modified.
-    - if [ -n "$(go fmt)" ]; then echo 'Code is not formatted with "go fmt"'; false; fi
-
-    # Perform static code analysys
-    - go vet `go list ./... | grep -v vendor`
-
-    # Fail builds when the cyclomatic complexity reaches 15 or more
-    - gocyclo -over 15 `find . -iname '*.go' | grep -v 'vendor' | grep -v '_test.go'`
-
-    # Verify that the Swagger docs are valid
-    - swagger-cli validate docs/*.yml
-
-    # Verify that the Swagger docs follow the autodeployment requirements
-    - if test "$(ls -A docs)"; then python2.7 verify_docs.py `find docs -name "*.yml"`; fi
-
-script:
-    # go list supply import paths for all sub directories.
-    # Exclude vendor directory, we don't want to run tests and coverage for all dependencies every time,
-    # also including their coverage may introduce to much noice. Concentrate on the coverage of local packages.
-    # Execute go test on every local subpackage (resolved as dependencies) and generate covreage report for each.
-    # Test packages pararell (xargs -P)
-    # Also build the docker container (with embedded build info), that will be pushed to dockerhub later on.
-    - if [ "$JOB_TYPE" = compile_and_basic_tests ]; then
-        go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $? ;
-
-        CGO_ENABLED=0 go build -ldflags "-X main.Commit=`echo $TRAVIS_COMMIT` -X main.Tag=`echo $TRAVIS_TAG` -X main.Branch=`echo $TRAVIS_BRANCH` -X main.BuildNumber=`echo $TRAVIS_BUILD_NUMBER`" ;
-        sudo docker build -t $DOCKER_REPOSITORY:pr . ;
-      fi
-
-    # Pull integration repo, copy build/run scripts
-    # Build container-under-test
-    # Build testing container
-    # Run tests
-    - if [ "$JOB_TYPE" = acceptance_tests ]; then
-        git clone -b master https://github.com/mendersoftware/integration.git;
-        mv integration/extra/travis-testing/* tests/ ;
-
-        CGO_ENABLED=0 go test -c -o useradm-test -coverpkg $(go list ./... | grep -v vendor | grep -v mocks | grep -v test | tr  '\n' ,);
-
-        sudo docker build -f Dockerfile.acceptance-testing -t mendersoftware/useradm:prtest .;
-
-        go build ;
-        ./tests/build-acceptance ./tests ./docs/internal_api.yml ./docs/management_api.yml useradm;
-
-        TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance.yml && TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance-multitenant.yml;
-      fi
-    - if [ "$JOB_TYPE" = backend_integration_tests ]; then
-        git clone -b master https://github.com/mendersoftware/integration.git;
-
-        CGO_ENABLED=0 go build;
-        sudo docker build -t mendersoftware/useradm:pr .;
-
-        ./integration/extra/release_tool.py --set-version-of mender-useradm --version pr;
-        ./integration/backend-tests/run;
-      fi
-
-after_success:
-    # Integrate with https://codecov.io
-    - if [[ "$JOB_TYPE" = compile_and_basic_tests ]]; then
-        bash <(curl -s https://codecov.io/bash) -F unittests ;
-      fi
-
-    - if [[ "$JOB_TYPE" = acceptance_tests ]]; then
-        bash <(curl -s https://codecov.io/bash) -F acceptance -f ./tests/coverage-acceptance.txt;
-      fi
-
-before_deploy:
-    # Upload image to docker registry only on PUSH
-    - if [ "$JOB_TYPE" = compile_and_basic_tests ]; then
-        if [ ! -z "$TRAVIS_TAG" ]; then export IMAGE_TAG=$TRAVIS_TAG; else export IMAGE_TAG=$TRAVIS_BRANCH; fi ;
-        docker tag $DOCKER_REPOSITORY:pr $DOCKER_REPOSITORY:$IMAGE_TAG ;
-        docker login --username=$DOCKER_HUB_USERNAME --password=$DOCKER_HUB_PASSWORD ;
-        docker push $DOCKER_REPOSITORY:$IMAGE_TAG ;
-
-        if [ "$TRAVIS_BRANCH" = master ]; then
-            export COMMIT_TAG="$TRAVIS_BRANCH"_"$TRAVIS_COMMIT";
-            docker tag $DOCKER_REPOSITORY:pr $DOCKER_REPOSITORY:$COMMIT_TAG;
-            docker push $DOCKER_REPOSITORY:$COMMIT_TAG;
-        fi;
-      fi
-
-deploy:
-
-    # Store docs for auto-deployment script
-    -
-        provider: s3
-        access_key_id: $AWS_ACCESS_KEY_ID
-        secret_access_key: $AWS_SECRET_ACCESS_KEY
-        bucket: $AWS_BUCKET_DOCS
-        region: $AWS_REGION
-        upload-dir: $TRAVIS_REPO_SLUG/latest/$TRAVIS_BRANCH
-        local_dir: docs
-        skip_cleanup: true
-        acl: public_read
-        on:
-            repo: $TRAVIS_REPO_SLUG
-            all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,8 +129,9 @@ jobs:
         - ./integration/backend-tests/run;
     - stage: Build and publish
       name: "dockerhub"
+      if: type = push
       install: skip
-      before_deploy:
+      script:
         - CGO_ENABLED=0 go build -ldflags "-X main.Commit=`echo $TRAVIS_COMMIT` -X main.Tag=`echo $TRAVIS_TAG` -X main.Branch=`echo $TRAVIS_BRANCH` -X main.BuildNumber=`echo $TRAVIS_BUILD_NUMBER`" ;
         - sudo docker build -t $DOCKER_REPOSITORY:pr . ;
         - if [ ! -z "$TRAVIS_TAG" ]; then export IMAGE_TAG=$TRAVIS_TAG; else export IMAGE_TAG=$TRAVIS_BRANCH; fi ;
@@ -143,13 +144,9 @@ jobs:
             docker tag $DOCKER_REPOSITORY:pr $DOCKER_REPOSITORY:$COMMIT_TAG;
             docker push $DOCKER_REPOSITORY:$COMMIT_TAG;
           fi;
-      # dummy deploy just to get the 'before_deploy' running
-      deploy:
-        -
-          provider: script
-          script: /bin/true
     - stage: Build and publish
       name: "docs"
+      if: type = push
       install: skip
       script: skip
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     matrix:
         - JOB_TYPE=compile_and_basic_tests
         - JOB_TYPE=acceptance_tests
+        - JOB_TYPE=backend_integration_tests
 
     global:
         # Should be encrypted or set as private travis variables (in travis settings):
@@ -128,6 +129,15 @@ script:
         ./tests/build-acceptance ./tests ./docs/internal_api.yml ./docs/management_api.yml useradm;
 
         TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance.yml && TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance-multitenant.yml;
+      fi
+    - if [ "$JOB_TYPE" = backend_integration_tests ]; then
+        git clone -b master https://github.com/mendersoftware/integration.git;
+
+        CGO_ENABLED=0 go build;
+        sudo docker build -t mendersoftware/useradm:pr .;
+
+        ./integration/extra/release_tool.py --set-version-of mender-useradm --version pr;
+        ./integration/backend-tests/run;
       fi
 
 after_success:


### PR DESCRIPTION
https://tracker.mender.io/browse/QA-27

if that's ok, I'll repeat this for all services.

changelog: none

Signed-off-by: mchalczynski <marcin.chalczynski@rndity.com>

PS. tried to also emit coverage report a'la acceptance tests by making some stuff common between the two (dockerfile driven by env vars, etc.) but this needs more consideration because of a lot of stupid quirks. do we want that? then I'll think about doing it independently from what we have in acceptance tests now.