### PR TITLE
MEN-2375 unauthorised for empty username logins

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Northern.tech AS
+Copyright 2019 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,7 +1,7 @@
 
 # These are identical to Apache-2.0 license.
-98ed35b5a138f58164b5c0dbccd9d7f01ef4d84b9dba01e896f0a3241c50c0f7  LICENSE
-98ed35b5a138f58164b5c0dbccd9d7f01ef4d84b9dba01e896f0a3241c50c0f7  vendor/github.com/mendersoftware/mendertesting/LICENSE
+beb140be4cd64599bedc691a55b2729c9cc611a4b9d6ec44e01270105daf18a2  LICENSE
+beb140be4cd64599bedc691a55b2729c9cc611a4b9d6ec44e01270105daf18a2  vendor/github.com/mendersoftware/mendertesting/LICENSE
 b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 5e3400b93bbb099e83e52bab885e7441750673c21f97988ca3f1240639b63283  vendor/github.com/spf13/afero/LICENSE.txt
 b40930bbcf80744c86c46a12bc9da056641d722716c378f5659b9e555ef833e1  vendor/gopkg.in/yaml.v2/LICENSE

--- a/user/useradm.go
+++ b/user/useradm.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2019 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -102,6 +102,10 @@ func NewUserAdm(jwtHandler jwt.Handler, db store.DataStore,
 
 func (u *UserAdm) Login(ctx context.Context, email, pass string) (*jwt.Token, error) {
 	var ident identity.Identity
+
+	if email == "" {
+		return nil, ErrUnauthorized
+	}
 
 	if u.verifyTenant {
 		// check the user's tenant

--- a/vendor/github.com/mendersoftware/mendertesting/LICENSE
+++ b/vendor/github.com/mendersoftware/mendertesting/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Northern.tech AS
+Copyright 2019 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.


### PR DESCRIPTION
Fixing MEN-2375

 . return unauthorised response for logins with empty username
 . Copyright date incremented

Changelog: Title

Signed-off-by: Peter Grzybowski <piotr@northern.tech>