### PR TITLE
Men 2655 align enterprise naming in tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ test:acceptance_tests:
     - docker load -i tests_image.tar
     - docker load -i acceptance_testing_image.tar
     - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose-acceptance.yml ;
-    - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose-acceptance-multitenant.yml ;
+    - TESTS_DIR=$(pwd)/tests $(pwd)/tests/run-test-environment acceptance $(pwd)/integration $(pwd)/tests/docker-compose-acceptance-enterprise.yml ;
   artifacts:
     expire_in: 2w
     paths:

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ jobs:
         - go build ;
         - ./tests/build-acceptance ./tests ./docs/internal_api.yml ./docs/management_api.yml useradm;
 
-        - TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance.yml && TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance-multitenant.yml;
+        - TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance.yml && TESTS_DIR=$PWD/tests ./tests/run-test-environment "acceptance" $PWD/integration ./tests/docker-compose-acceptance-enterprise.yml;
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F acceptance -f ./tests/coverage-acceptance.txt;
     - stage: Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ jobs:
         - sudo docker build -t mendersoftware/useradm:pr .;
 
         - ./integration/extra/release_tool.py --set-version-of mender-useradm --version pr;
-        - PYTEST_ARGS="-k 'not Multitenant'"./integration/backend-tests/run;
+        - PYTEST_ARGS="-k 'not Enterprise'"./integration/backend-tests/run;
     - stage: Build and publish
       name: "dockerhub"
       if: type = push

--- a/tests/docker-compose-acceptance-enterprise.yml
+++ b/tests/docker-compose-acceptance-enterprise.yml
@@ -8,8 +8,8 @@ services:
             - "${TESTS_DIR}:/testing"
         depends_on:
             - mender-useradm
-        # run multi tenant tests only
-        command: -k Multitenant
+        # run enterprise tests only
+        command: -k Enterprise
         environment:
             FAKE_TENANTADM_ADDR: "0.0.0.0:9997"
     mender-useradm:

--- a/tests/docker-compose-acceptance.yml
+++ b/tests/docker-compose-acceptance.yml
@@ -8,7 +8,7 @@ services:
             - "${TESTS_DIR}:/testing"
         depends_on:
             - mender-useradm
-        command: -k 'not Multitenant'
+        command: -k 'not Enterprise'
     mender-useradm:
         image: mendersoftware/useradm:prtest
         networks:

--- a/tests/tests/test_api_internal.py
+++ b/tests/tests/test_api_internal.py
@@ -42,7 +42,7 @@ class TestInternalApiTenantCreate:
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 400
 
-class TestInternalApiUserForTenantCreateMultitenant:
+class TestInternalApiUserForTenantCreateEnterprise:
     def test_ok(self, api_client_int,api_client_mgmt, clean_db, ):
         user = {"email":"stefan@example.com", "password":"secret12345"}
 

--- a/tests/tests/test_api_management.py
+++ b/tests/tests/test_api_management.py
@@ -90,7 +90,7 @@ class TestManagementApiPostUsers(TestManagementApiPostUsersBase):
         self._do_test_fail_duplicate_email(api_client_mgmt, init_users, new_user)
 
 
-class TestManagementApiPostUsersMultitenant(TestManagementApiPostUsersBase):
+class TestManagementApiPostUsersEnterprise(TestManagementApiPostUsersBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, tenant_id, api_client_mgmt, init_users_mt):
         new_user = {"email":"foo@bar.com", "password": "asdf1234zxcv"}
@@ -135,7 +135,7 @@ class TestManagementApiGetUser(TestManagementApiGetUserBase):
         self._do_test_fail_not_found(api_client_mgmt, init_users)
 
 
-class TestManagementApiGetUserMultitenant(TestManagementApiGetUserBase):
+class TestManagementApiGetUserEnterprise(TestManagementApiGetUserBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, tenant_id, api_client_mgmt, init_users_mt):
         self._do_test_ok(api_client_mgmt, init_users_mt[tenant_id], tenant_id)
@@ -170,7 +170,7 @@ class TestManagementApiGetUsersNoUsers(TestManagementApiGetUsersBase):
     def test_no_users(self, api_client_mgmt):
         self._do_test_no_users(api_client_mgmt)
 
-class TestManagementApiGetUsersMultitenant(TestManagementApiGetUsersBase):
+class TestManagementApiGetUsersEnterprise(TestManagementApiGetUsersBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, tenant_id, api_client_mgmt, init_users_mt):
         self._do_test_ok(api_client_mgmt, init_users_mt[tenant_id], tenant_id)
@@ -212,7 +212,7 @@ class TestManagementApiDeleteUser(TestManagementApiDeleteUserBase):
         self._do_test_not_found(api_client_mgmt)
 
 
-class TestManagementApiDeleteUserMultitenant(TestManagementApiDeleteUserBase):
+class TestManagementApiDeleteUserEnterprise(TestManagementApiDeleteUserBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, tenant_id, api_client_mgmt, init_users_mt):
         with tenantadm.run_fake_delete_user(tenant_id, init_users_mt[tenant_id][0]['id']):
@@ -320,7 +320,7 @@ class TestManagementApiPutUser(TestManagementApiPutUserBase):
         self._do_test_fail_duplicate_email(api_client_mgmt, init_users_f, init_users_f[0], update)
 
 
-class TestManagementApiPutUserMultitenant(TestManagementApiPutUserBase):
+class TestManagementApiPutUserEnterprise(TestManagementApiPutUserBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok_email(self, api_client_mgmt, init_users_mt_f, tenant_id):
         user = init_users_mt_f[tenant_id][0]
@@ -409,7 +409,7 @@ class TestManagementApiSettings(TestManagementApiSettingsBase):
     def test_bad_request(self, api_client_mgmt):
         self._do_test_fail_bad_request(api_client_mgmt)
 
-class TestManagementApiSettingsMultitenant(TestManagementApiSettingsBase):
+class TestManagementApiSettingsEnterprise(TestManagementApiSettingsBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, api_client_mgmt, init_users_mt_f, tenant_id):
         self._do_test_ok(api_client_mgmt, tenant_id)

--- a/tests/tests/test_auth.py
+++ b/tests/tests/test_auth.py
@@ -48,7 +48,7 @@ class TestAuthLogin:
         assert 'mender.user' in claims and claims['mender.user'] == True
 
 
-class TestAuthLoginMultitenant:
+class TestAuthLoginEnterprise:
     def test_ok(self, api_client_mgmt, init_users_mt):
         password = "correcthorsebatterystaple"
 

--- a/tests/tests/test_cli.py
+++ b/tests/tests/test_cli.py
@@ -101,7 +101,7 @@ class TestCli:
                                    Migration.DB_VERSION)
 
 
-class TestCliMultitenant:
+class TestCliEnterprise:
     def test_create_user(self, api_client_mgmt, cli):
         cli.create_user('foo-tenant1id@bar.com', '1234youseeme',
                         tenant_id='tenant1id')

--- a/tests/tests/test_tokens_delete.py
+++ b/tests/tests/test_tokens_delete.py
@@ -62,7 +62,7 @@ def user_tokens_mt_f(init_users_mt_f, api_client_mgmt):
 
     yield tokens
 
-class TestDeleteTokensMultitenant:
+class TestDeleteTokensEnterprise:
 
     def test_delete_by_user_ok(self, api_client_int, user_tokens_mt_f):
         tokens = user_tokens_mt_f


### PR DESCRIPTION
The last two commits are not entirely in scope of the issue, but are rather to align the remainder of the code with the enterprise naming (I'll just drop the commits and update if this should be put into a separate issue instead)