### PR TITLE
[MEN-3389] Token management API

### DIFF
--- a/authz/middleware_test.go
+++ b/authz/middleware_test.go
@@ -304,7 +304,7 @@ func TestGetRequestToken(t *testing.T) {
 		Claims: jwt.Claims{
 			Subject:   uuid.NewSHA1("foo"),
 			Issuer:    "bar",
-			ExpiresAt: jwt.Time{Time: time.Unix(12345, 0)},
+			ExpiresAt: &jwt.Time{Time: time.Unix(12345, 0)},
 		},
 	}
 

--- a/authz_simple_test.go
+++ b/authz_simple_test.go
@@ -44,7 +44,7 @@ func TestSimpleAuthzAuthorize(t *testing.T) {
 				Claims: jwt.Claims{
 					Subject: uuid.NewSHA1("testsubject"),
 					Issuer:  "mender",
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().Add(time.Hour),
 					},
 					Scope: scope.All,
@@ -57,7 +57,7 @@ func TestSimpleAuthzAuthorize(t *testing.T) {
 			inToken: &jwt.Token{
 				Claims: jwt.Claims{
 					Issuer: "mender",
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().Add(time.Hour),
 					},
 					Subject: uuid.NewSHA1("testsubject"),
@@ -71,7 +71,7 @@ func TestSimpleAuthzAuthorize(t *testing.T) {
 			inToken: &jwt.Token{
 				Claims: jwt.Claims{
 					Issuer: "mender",
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().Add(time.Hour),
 					},
 					Subject: uuid.NewSHA1("testsubject"),

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -305,6 +305,38 @@ paths:
 
   /tokens:
     get:
+      summary: Get all active tokens for user
+      description: |
+        Retrieves a list of all valid JWT tokens assigned to this user.
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          type: string
+          format: Bearer [token]
+          description: Contains the JWT token issued by the User Administration and Authentication Service.
+      responses:
+        200:
+          description: All valid API tokens issued for the requesting user.
+          content:
+            application/json:
+              schema:
+                type: array
+                description: String-type list of JWT tokens.
+                name: Tokens
+                items:
+                  string
+        401:
+          description: |
+                The user cannot be granted authentication.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: "#/definitions/Error"
+
+    post:
       summary: Create a new permanent API token.
       description: |
         Create a new API token that remains valid until explicitly deleted.

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -303,6 +303,71 @@ paths:
           schema:
             $ref: "#/definitions/Error"
 
+  /tokens:
+    get:
+      summary: Create a new permanent API token.
+      description: |
+        Create a new API token that remains valid until explicitly deleted.
+        The generated token will be associated with the calling user, thus
+        inherit the user's permission scope.
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          type: string
+          format: Bearer [token]
+          description: Contains the JWT token issued by the User Administration and Authentication Service.
+      responses:
+        200:
+          description: API token generated and present in the payload.
+          examples:
+            application/jwt:
+              eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJNZW5kZXIiLCJzdWIiO
+              iI4NTRiMzEwOS00ODYyLTRhMjUtYTFmYi1mMTExNjFjZTdhODQiLCJzY3AiOlsibWV
+              uZGVyLioiXX0.XEToCrrn4ZIhIFpJO_i6NXixoMG0t5o0xgnlgTlhUGIFj_QEOuLkt
+              FeMaLH0RyK2jytTn1pvZ2WLl1QkKS9QwFSqD62tLWDVq-t6lIrjms_TgjilwlLNm8u
+              E29yow62LQF-Q_SZodTbRylZLdACZXqcd8bwSj0GgVKU7hu-JUViptbiSyVYwq-zpt
+              KEfc5F0yk6d4Tvv5r1JkTbSBPOqYexoKyPe4TQReZzxUTe3560jzXHIt-N6hiLTC1R
+              axlrDwMKAfdY-dAjoQBiYudJennlCyXp8seclVScJyn_1kyaTLgbfRp5jBZTQtr9TS
+              Va6s_VFCDWV1j8OCjYhEwFkIQ
+        401:
+          description: |
+            The user is not authenticated.
+          schema:
+            $ref: "#/definitions/Error"
+        500:
+          description: Internal server error.
+          schema:
+            $ref: "#/definitions/Error"
+
+    delete:
+      summary: Deletes the calling token.
+      description: |
+        Deletes the token carried in the request header, effectively
+        invalidating the token from future use. Applies to any token generated
+        by the GET /tokens and POST /auth/login endpoints.
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          type: string
+          format: Bearer [token]
+          description: Contains the JWT token issued by the User Administration and Authentication Service.
+      responses:
+        204:
+          description: |
+            JWToken successfully removed.
+        401:
+          description: |
+            Caller token is not authorized.
+          schema:
+            $ref: "#/definitions/Error"
+        500:
+          description: Internal server error.
+          schema:
+            $ref: "#/definitions/Error"
+
+
 definitions:
   UserNew:
     description: New user descriptor.

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -26,9 +26,9 @@ type Claims struct {
 	// Subject holds the UUID associated with the user's account.
 	Subject uuid.UUID `json:"sub,omitempty" bson:"sub,omitempty"`
 	// ExpiresAt is the absolute time when the token expires.
-	ExpiresAt Time `json:"exp,omitempty" bson:"exp,omitempty"`
+	ExpiresAt *Time `json:"exp,omitempty" bson:"exp,omitempty"`
 	// IssuedAt is the absolute time the token was created.
-	IssuedAt Time `json:"iat,omitempty" bson:"iat,omitempty"`
+	IssuedAt *Time `json:"iat,omitempty" bson:"iat,omitempty"`
 	// Tenant holds the tenant ID claim
 	Tenant string `json:"mender.tenant,omitempty" bson:"tenant,omitempty"`
 	// User claims that this token is for the management API.
@@ -38,7 +38,7 @@ type Claims struct {
 	// Scope determines the API scope of the token (defaults to "mender.*")
 	Scope     string `json:"scp,omitempty" bson:"scp,omitempty"`
 	Audience  string `json:"aud,omitempty" bson:"aud,omitempty"`
-	NotBefore Time   `json:"nbf,omitempty" bson:"nbf,omitempty"`
+	NotBefore *Time  `json:"nbf,omitempty" bson:"nbf,omitempty"`
 }
 
 // Time is a simple wrapper of time.Time that marshals/unmarshals JSON
@@ -73,10 +73,11 @@ func (c *Claims) Valid() error {
 		c.Scope == "" {
 		return ErrTokenInvalid
 	}
-
-	now := time.Now()
-	if now.After(c.ExpiresAt.Time) {
-		return ErrTokenExpired
+	if c.ExpiresAt != nil {
+		now := time.Now()
+		if now.After(c.ExpiresAt.Time) {
+			return ErrTokenExpired
+		}
 	}
 
 	return nil

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -44,7 +44,7 @@ func TestJWTHandlerRS256GenerateToken(t *testing.T) {
 			claims: Claims{
 				Issuer:  "Mender",
 				Subject: uuid.NewSHA1("foo"),
-				ExpiresAt: Time{
+				ExpiresAt: &Time{
 					Time: time.Now().Add(time.Hour),
 				},
 			},
@@ -95,10 +95,10 @@ func TestJWTHandlerRS256FromJWT(t *testing.T) {
 				Claims: Claims{
 					ID:      uuid.NewSHA1("someid"),
 					Subject: uuid.NewSHA1("foo"),
-					ExpiresAt: Time{
+					ExpiresAt: &Time{
 						Time: time.Unix(4481893900, 0),
 					},
-					IssuedAt: Time{
+					IssuedAt: &Time{
 						Time: time.Unix(1234567, 0),
 					},
 					Audience: "Mender",
@@ -130,10 +130,10 @@ func TestJWTHandlerRS256FromJWT(t *testing.T) {
 				Claims: Claims{
 					ID:      uuid.NewSHA1("someid"),
 					Subject: uuid.NewSHA1("foo"),
-					ExpiresAt: Time{
+					ExpiresAt: &Time{
 						Time: time.Unix(4481893900, 0),
 					},
-					IssuedAt: Time{
+					IssuedAt: &Time{
 						Time: time.Unix(1234567, 0),
 					},
 					Issuer:   "Mender",
@@ -165,10 +165,10 @@ func TestJWTHandlerRS256FromJWT(t *testing.T) {
 				Claims: Claims{
 					ID:      uuid.NewSHA1("someid"),
 					Subject: uuid.NewSHA1("foo"),
-					ExpiresAt: Time{
+					ExpiresAt: &Time{
 						Time: time.Unix(4481893900, 0),
 					},
-					IssuedAt: Time{
+					IssuedAt: &Time{
 						Time: time.Unix(1234567, 0),
 					},
 					Issuer: "Mender",

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -55,6 +55,8 @@ type DataStore interface {
 
 	SaveSettings(ctx context.Context, s map[string]interface{}) error
 	GetSettings(ctx context.Context) (map[string]interface{}, error)
+
+	DeleteToken(ctx context.Context, jti uuid.UUID) error
 }
 
 // TenantDataKeeper is an interface for executing administrative opeartions on

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -46,6 +46,7 @@ type DataStore interface {
 	DeleteUser(ctx context.Context, id string) error
 	SaveToken(ctx context.Context, token *jwt.Token) error
 	GetTokenById(ctx context.Context, id uuid.UUID) (*jwt.Token, error)
+	GetTokensByUserID(ctx context.Context, id uuid.UUID) ([]*jwt.Token, error)
 
 	// deletes all tenant's tokens (identity in context)
 	DeleteTokens(ctx context.Context) error

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -141,6 +141,32 @@ func (_m *DataStore) GetTokenById(ctx context.Context, id uuid.UUID) (*jwt.Token
 	return r0, r1
 }
 
+func (_m *DataStore) GetTokensByUserID(
+	ctx context.Context, id uuid.UUID,
+) ([]*jwt.Token, error) {
+	ret := _m.Called(ctx, id)
+
+	var r0 []*jwt.Token
+	if rf, ok := ret.Get(0).(func(
+		context.Context, uuid.UUID,
+	) []*jwt.Token); ok {
+		r0 = rf(ctx, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*jwt.Token)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, uuid.UUID) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetUserByEmail provides a mock function with given fields: ctx, email
 func (_m *DataStore) GetUserByEmail(ctx context.Context, email string) (*model.User, error) {
 	ret := _m.Called(ctx, email)

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -41,6 +41,18 @@ func (_m *DataStore) CreateUser(ctx context.Context, u *model.User) error {
 	return r0
 }
 
+func (_m *DataStore) DeleteToken(ctx context.Context, jti uuid.UUID) error {
+	ret := _m.Called(ctx, jti)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, uuid.UUID) error); ok {
+		r0 = rf(ctx, jti)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
 // DeleteTokens provides a mock function with given fields: ctx
 func (_m *DataStore) DeleteTokens(ctx context.Context) error {
 	ret := _m.Called(ctx)

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -256,6 +256,25 @@ func (db *DataStoreMongo) GetTokenById(ctx context.Context, id uuid.UUID) (*jwt.
 	return &token, nil
 }
 
+func (db *DataStoreMongo) GetTokensByUserID(
+	ctx context.Context,
+	uid uuid.UUID,
+) ([]*jwt.Token, error) {
+	var ret []*jwt.Token
+
+	database := db.client.Database(mstore.DbFromContext(ctx, DbName))
+	collTkns := database.Collection(DbTokensColl)
+	cur, err := collTkns.Find(ctx, bson.M{"sub": uid})
+	if err != nil {
+		return nil, err
+	}
+	err = cur.All(ctx, &ret)
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func (db *DataStoreMongo) GetUsers(ctx context.Context) ([]model.User, error) {
 	o := mopts.Find()
 	o.SetProjection(bson.M{DbUserPass: 0})

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -360,6 +360,14 @@ func (db *DataStoreMongo) DeleteTokens(ctx context.Context) error {
 	return err
 }
 
+func (db *DataStoreMongo) DeleteToken(ctx context.Context, jti uuid.UUID) error {
+	database := db.client.Database(mstore.DbFromContext(ctx, DbName))
+	collTkns := database.Collection(DbTokensColl)
+
+	_, err := collTkns.DeleteOne(ctx, bson.M{"_id": jti})
+	return err
+}
+
 // deletes all user's tokens
 func (db *DataStoreMongo) DeleteTokensByUserId(ctx context.Context, userId string) error {
 	c := db.client.

--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -38,18 +38,30 @@ func assertEqualTokens(t *testing.T, expected, actual *jwt.Token) bool {
 	ret = assert.Equal(t, expected.ID, actual.ID)
 	ret = ret && assert.Equal(t, expected.Subject, actual.Subject)
 	ret = ret && assert.Equal(t, expected.Audience, actual.Audience)
-	ret = ret && assert.WithinDuration(t,
-		expected.ExpiresAt.Time,
-		actual.ExpiresAt.Time, time.Second)
-	ret = ret && assert.WithinDuration(t,
-		expected.IssuedAt.Time,
-		actual.IssuedAt.Time, time.Second)
-	ret = ret && assert.WithinDuration(t,
-		expected.NotBefore.Time,
-		actual.NotBefore.Time, time.Second)
 	ret = ret && assert.Equal(t, expected.Issuer, actual.Issuer)
 	ret = ret && assert.Equal(t, expected.Scope, actual.Scope)
 	ret = ret && assert.Equal(t, expected.Tenant, actual.Tenant)
+	if expected.ExpiresAt == nil {
+		ret = ret && assert.Equal(t, expected.ExpiresAt, actual.ExpiresAt.Time)
+	} else {
+		ret = ret && assert.WithinDuration(t,
+			expected.ExpiresAt.Time,
+			actual.ExpiresAt.Time, time.Second)
+	}
+	if expected.IssuedAt == nil {
+		ret = ret && assert.Equal(t, expected.IssuedAt, actual.IssuedAt)
+	} else {
+		ret = ret && assert.WithinDuration(t,
+			expected.IssuedAt.Time,
+			actual.IssuedAt.Time, time.Second)
+	}
+	if expected.NotBefore == nil {
+		ret = ret && assert.Equal(t, expected.NotBefore, actual.NotBefore)
+	} else {
+		ret = ret && assert.WithinDuration(t,
+			expected.NotBefore.Time,
+			actual.NotBefore.Time, time.Second)
+	}
 	return ret && assert.Equal(t, expected.User, actual.User)
 }
 
@@ -458,10 +470,10 @@ func TestMongoGetTokenById(t *testing.T) {
 				ID:        uuid.NewSHA1("id-1"),
 				Subject:   uuid.NewSHA1("sub-1"),
 				Audience:  "audience",
-				ExpiresAt: jwt.Time{Time: time.Now().Add(time.Hour)},
-				IssuedAt:  jwt.Time{Time: time.Now()},
+				ExpiresAt: &jwt.Time{Time: time.Now().Add(time.Hour)},
+				IssuedAt:  &jwt.Time{Time: time.Now()},
 				Issuer:    "iss-1",
-				NotBefore: jwt.Time{Time: time.Unix(7890, 0)},
+				NotBefore: &jwt.Time{Time: time.Unix(7890, 0)},
 				Scope:     "scope-1",
 				Tenant:    "tenantID1",
 				User:      true,
@@ -472,10 +484,10 @@ func TestMongoGetTokenById(t *testing.T) {
 				ID:        uuid.NewSHA1("id-2"),
 				Subject:   uuid.NewSHA1("sub-2"),
 				Audience:  "audience",
-				ExpiresAt: jwt.Time{Time: time.Now().Add(time.Hour)},
-				IssuedAt:  jwt.Time{Time: time.Now()},
+				ExpiresAt: &jwt.Time{Time: time.Now().Add(time.Hour)},
+				IssuedAt:  &jwt.Time{Time: time.Now()},
 				Issuer:    "iss-2",
-				NotBefore: jwt.Time{Time: time.Unix(7890, 0)},
+				NotBefore: &jwt.Time{Time: time.Unix(7890, 0)},
 				Scope:     "scope-2",
 				Tenant:    "tenantID2",
 				User:      true,
@@ -763,12 +775,12 @@ func TestMongoSaveToken(t *testing.T) {
 					ID:       uuid.NewSHA1("id-3"),
 					Subject:  uuid.NewSHA1("sub-3"),
 					Audience: "audience",
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().Add(time.Hour),
 					},
-					IssuedAt: jwt.Time{Time: time.Now()},
+					IssuedAt: &jwt.Time{Time: time.Now()},
 					Issuer:   "iss-3",
-					NotBefore: jwt.Time{
+					NotBefore: &jwt.Time{
 						Time: time.Unix(7890, 0),
 					},
 					Scope:  "scope-3",
@@ -782,10 +794,10 @@ func TestMongoSaveToken(t *testing.T) {
 				Claims: jwt.Claims{
 					ID:      uuid.NewSHA1("id-4"),
 					Subject: uuid.NewSHA1("sub-4"),
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().Add(time.Hour),
 					},
-					IssuedAt: jwt.Time{Time: time.Now()},
+					IssuedAt: &jwt.Time{Time: time.Now()},
 					Tenant:   "tenantID4",
 					User:     true,
 				},
@@ -797,12 +809,12 @@ func TestMongoSaveToken(t *testing.T) {
 					ID:       uuid.NewSHA1("id-3"),
 					Subject:  uuid.NewSHA1("sub-3"),
 					Audience: "audience",
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().Add(time.Hour),
 					},
-					IssuedAt: jwt.Time{Time: time.Now()},
+					IssuedAt: &jwt.Time{Time: time.Now()},
 					Issuer:   "iss-3",
-					NotBefore: jwt.Time{
+					NotBefore: &jwt.Time{
 						Time: time.Unix(7890, 0),
 					},
 					Scope:  "scope-3",
@@ -998,15 +1010,15 @@ func TestMongoDeleteTokens(t *testing.T) {
 						ID:       uuid.NewSHA1("id-1"),
 						Subject:  uuid.NewSHA1("sub-1"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1018,15 +1030,15 @@ func TestMongoDeleteTokens(t *testing.T) {
 						ID:       uuid.NewSHA1("id-2"),
 						Subject:  uuid.NewSHA1("sub-1"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1038,15 +1050,15 @@ func TestMongoDeleteTokens(t *testing.T) {
 						ID:       uuid.NewSHA1("id-3"),
 						Subject:  uuid.NewSHA1("sub-2"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-2",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-2",
@@ -1063,15 +1075,15 @@ func TestMongoDeleteTokens(t *testing.T) {
 						ID:       uuid.NewSHA1("id-1"),
 						Subject:  uuid.NewSHA1("sub-1"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope:  "scope-1",
@@ -1084,15 +1096,15 @@ func TestMongoDeleteTokens(t *testing.T) {
 						ID:       uuid.NewSHA1("id-2"),
 						Subject:  uuid.NewSHA1("sub-1"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope:  "scope-1",
@@ -1174,15 +1186,15 @@ func TestMongoDeleteTokensByUserId(t *testing.T) {
 						ID:       uuid.NewSHA1("id-1"),
 						Subject:  uuid.NewSHA1("user-1"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1194,15 +1206,15 @@ func TestMongoDeleteTokensByUserId(t *testing.T) {
 						ID:       uuid.NewSHA1("id-2"),
 						Subject:  uuid.NewSHA1("user-1"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1214,15 +1226,15 @@ func TestMongoDeleteTokensByUserId(t *testing.T) {
 						ID:       uuid.NewSHA1("id-3"),
 						Subject:  uuid.NewSHA1("user-2"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1236,15 +1248,15 @@ func TestMongoDeleteTokensByUserId(t *testing.T) {
 						ID:       uuid.NewSHA1("id-3"),
 						Subject:  uuid.NewSHA1("user-2"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1262,15 +1274,15 @@ func TestMongoDeleteTokensByUserId(t *testing.T) {
 						ID:       uuid.NewSHA1("id-1"),
 						Subject:  uuid.NewSHA1("user-1"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1282,15 +1294,15 @@ func TestMongoDeleteTokensByUserId(t *testing.T) {
 						ID:       uuid.NewSHA1("id-2"),
 						Subject:  uuid.NewSHA1("user-1"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1302,15 +1314,15 @@ func TestMongoDeleteTokensByUserId(t *testing.T) {
 						ID:       uuid.NewSHA1("id-3"),
 						Subject:  uuid.NewSHA1("user-2"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",
@@ -1324,15 +1336,15 @@ func TestMongoDeleteTokensByUserId(t *testing.T) {
 						ID:       uuid.NewSHA1("id-3"),
 						Subject:  uuid.NewSHA1("user-2"),
 						Audience: "audience",
-						ExpiresAt: jwt.Time{
+						ExpiresAt: &jwt.Time{
 							Time: time.Now().
 								Add(time.Hour),
 						},
-						IssuedAt: jwt.Time{
+						IssuedAt: &jwt.Time{
 							Time: time.Now(),
 						},
 						Issuer: "iss-1",
-						NotBefore: jwt.Time{
+						NotBefore: &jwt.Time{
 							Time: time.Unix(7890, 0),
 						},
 						Scope: "scope-1",

--- a/store/mongo/migration_1_0_0_test.go
+++ b/store/mongo/migration_1_0_0_test.go
@@ -47,7 +47,7 @@ func TestMigration_1_0_0(t *testing.T) {
 				jwt.Token{Claims: jwt.Claims{
 					ID:      uuid.NewSHA1("foo"),
 					Subject: uuid.NewSHA1("bar"),
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().
 							Add(time.Hour).
 							Round(time.Second),
@@ -58,7 +58,7 @@ func TestMigration_1_0_0(t *testing.T) {
 				jwt.Token{Claims: jwt.Claims{
 					ID:      uuid.NewSHA1("baz"),
 					Subject: uuid.NewSHA1("bar"),
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().
 							Add(time.Hour).
 							Round(time.Second),
@@ -71,7 +71,7 @@ func TestMigration_1_0_0(t *testing.T) {
 				jwt.Token{Claims: jwt.Claims{
 					ID:      uuid.NewSHA1("foo"),
 					Subject: uuid.NewSHA1("bar"),
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().
 							Add(time.Hour).
 							Round(time.Second),
@@ -82,7 +82,7 @@ func TestMigration_1_0_0(t *testing.T) {
 				jwt.Token{Claims: jwt.Claims{
 					ID:      uuid.NewSHA1("baz"),
 					Subject: uuid.NewSHA1("bar"),
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().
 							Add(time.Hour).
 							Round(time.Second),
@@ -100,7 +100,7 @@ func TestMigration_1_0_0(t *testing.T) {
 				jwt.Token{Claims: jwt.Claims{
 					ID:      uuid.NewSHA1("foo"),
 					Subject: uuid.NewSHA1("bar"),
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().
 							Add(time.Hour).
 							Round(time.Second),
@@ -111,7 +111,7 @@ func TestMigration_1_0_0(t *testing.T) {
 				jwt.Token{Claims: jwt.Claims{
 					ID:      uuid.NewSHA1("baz"),
 					Subject: uuid.NewSHA1("bar"),
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().
 							Add(-time.Hour).
 							Round(time.Second),
@@ -124,7 +124,7 @@ func TestMigration_1_0_0(t *testing.T) {
 				jwt.Token{Claims: jwt.Claims{
 					ID:      uuid.NewSHA1("foo"),
 					Subject: uuid.NewSHA1("bar"),
-					ExpiresAt: jwt.Time{
+					ExpiresAt: &jwt.Time{
 						Time: time.Now().
 							Add(time.Hour).
 							Round(time.Second),

--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -24,31 +24,31 @@ import requests
 
 class ApiClient:
     config = {
-        'also_return_response': True,
-        'validate_responses': True,
-        'validate_requests': False,
-        'validate_swagger_spec': False,
-        'use_models': True,
+        "also_return_response": True,
+        "validate_responses": True,
+        "validate_requests": False,
+        "validate_swagger_spec": False,
+        "use_models": True,
     }
 
-    log = logging.getLogger('client.ApiClient')
+    log = logging.getLogger("client.ApiClient")
     # override spec_option for internal vs management clients
-    spec_option = 'internal-spec'
-    api_url = "http://%s/api/0.1.0/" % \
-              pytest.config.getoption("host")
+    spec_option = "internal-spec"
+    api_url = "http://%s/api/0.1.0/" % pytest.config.getoption("host")
 
     def make_api_url(self, path):
-        return os.path.join(self.api_url,
-                            path if not path.startswith("/") else path[1:])
+        return os.path.join(
+            self.api_url, path if not path.startswith("/") else path[1:]
+        )
 
     def setup_swagger(self):
         self.http_client = RequestsClient()
         self.http_client.session.verify = False
 
         spec = pytest.config.getoption(self.spec_option)
-        self.client = SwaggerClient.from_spec(load_file(spec),
-                                              config=self.config,
-                                              http_client=self.http_client)
+        self.client = SwaggerClient.from_spec(
+            load_file(spec), config=self.config, http_client=self.http_client
+        )
         self.client.swagger_spec.api_url = self.api_url
 
     def __init__(self):
@@ -56,37 +56,39 @@ class ApiClient:
 
 
 class InternalApiClient(ApiClient):
-    log = logging.getLogger('client.InternalClient')
-    spec_option = 'internal_spec'
-    api_url = "http://%s/api/internal/v1/useradm/" % \
-              pytest.config.getoption("host")
+    log = logging.getLogger("client.InternalClient")
+    spec_option = "internal_spec"
+    api_url = "http://%s/api/internal/v1/useradm/" % pytest.config.getoption("host")
 
     def __init__(self):
         super().__init__()
 
-    def verify(self, token, uri='/api/management/1.0/auth/verify', method='POST'):
-        if not token.startswith('Bearer '):
+    def verify(self, token, uri="/api/management/1.0/auth/verify", method="POST"):
+        if not token.startswith("Bearer "):
             token = "Bearer " + token
-        return self.client.auth.post_auth_verify(**{
-            'Authorization': token,
-            'X-Original-URI': uri,
-            'X-Original-Method' :method,
-        }).result()
+        return self.client.auth.post_auth_verify(
+            **{
+                "Authorization": token,
+                "X-Original-URI": uri,
+                "X-Original-Method": method,
+            }
+        ).result()
 
     def create_tenant(self, tenant_id):
-        return self.client.tenants.post_tenants(tenant={
-            "tenant_id": tenant_id,
-        }).result()
+        return self.client.tenants.post_tenants(
+            tenant={"tenant_id": tenant_id,}
+        ).result()
 
     def create_user_for_tenant(self, tenant_id, user):
-        return self.client.tenants.post_tenants_tenant_id_users(tenant_id = tenant_id, user = user).result()
+        return self.client.tenants.post_tenants_tenant_id_users(
+            tenant_id=tenant_id, user=user
+        ).result()
 
 
 class ManagementApiClient(ApiClient):
-    log = logging.getLogger('client.ManagementClient')
-    spec_option = 'management_spec'
-    api_url = "http://%s/api/management/v1/useradm/" % \
-              pytest.config.getoption("host")
+    log = logging.getLogger("client.ManagementClient")
+    spec_option = "management_spec"
+    api_url = "http://%s/api/management/v1/useradm/" % pytest.config.getoption("host")
 
     # default user auth - single user, single tenant
     auth = {"Authorization": "Bearer foobarbaz"}
@@ -96,36 +98,46 @@ class ManagementApiClient(ApiClient):
 
     def get_users(self, auth=None):
         if auth is None:
-            auth=self.auth
+            auth = self.auth
 
-        return self.client.users.get_users(_request_options={"headers": auth}).result()[0]
+        return self.client.users.get_users(_request_options={"headers": auth}).result()[
+            0
+        ]
 
     def get_user(self, uid, auth=None):
         if auth is None:
-            auth=self.auth
+            auth = self.auth
 
-        return self.client.users.get_users_id(id=uid, _request_options={"headers": auth}).result()[0]
+        return self.client.users.get_users_id(
+            id=uid, _request_options={"headers": auth}
+        ).result()[0]
 
     def create_user(self, user, auth=None):
         if auth is None:
-            auth=self.auth
+            auth = self.auth
 
-        return self.client.users.post_users(user=user, _request_options={"headers": auth}).result()
+        return self.client.users.post_users(
+            user=user, _request_options={"headers": auth}
+        ).result()
 
     def delete_user(self, user_id, auth=None, headers={}):
         if auth is None:
-            auth=self.auth
+            auth = self.auth
 
-        headers['Authorization'] = auth['Authorization']
+        headers["Authorization"] = auth["Authorization"]
         # bravado for some reason doesn't issue DELETEs properly (silent failure)
-        rsp = requests.delete(self.make_api_url('/users/{}'.format(user_id)), headers=headers)
+        rsp = requests.delete(
+            self.make_api_url("/users/{}".format(user_id)), headers=headers
+        )
         return rsp
 
     def update_user(self, uid, update, auth=None):
         if auth is None:
-            auth=self.auth
+            auth = self.auth
 
-        return self.client.users.put_users_id(id=uid, user_update=update, _request_options={"headers": auth}).result()
+        return self.client.users.put_users_id(
+            id=uid, user_update=update, _request_options={"headers": auth}
+        ).result()
 
     def login(self, username, password):
         auth = common.make_basic_auth(username, password)
@@ -133,49 +145,82 @@ class ManagementApiClient(ApiClient):
 
     def post_settings(self, settings, auth=None):
         if auth is None:
-            auth=self.auth
+            auth = self.auth
 
-        return requests.post(self.make_api_url('/settings'), json=settings, headers=auth)
+        return requests.post(
+            self.make_api_url("/settings"), json=settings, headers=auth
+        )
 
     def get_settings(self, auth=None):
         if auth is None:
-            auth=self.auth
+            auth = self.auth
 
-        return requests.get(self.make_api_url('/settings'), headers=auth)
+        return requests.get(self.make_api_url("/settings"), headers=auth)
+
+    def create_api_token(self, auth=None):
+        if auth is None:
+            auth = self.auth
+
+        if isinstance(auth, dict):
+            auth = auth["Authorization"]
+        elif isinstance(auth, str):
+            auth = "Bearer " + auth
+        return self.client.tokens.post_tokens(Authorization=auth).result()
+
+    def delete_api_token(self, auth=None):
+        if auth is None:
+            auth = self.auth
+
+        if isinstance(auth, dict):
+            auth = auth["Authorization"]
+        elif isinstance(auth, str):
+            auth = "Bearer " + auth
+        return self.client.tokens.delete_tokens(Authorization=auth).result()
+
+    def get_tokens(self, auth=None):
+        if auth is None:
+            auth = self.auth
+
+        if isinstance(auth, dict):
+            auth = auth["Authorization"]
+        elif isinstance(auth, str):
+            auth = "Bearer " + auth
+        return self.client.tokens.get_tokens(Authorization=auth).result()
 
 
 class CliClient:
-    cmd = '/testing/useradm'
+    cmd = "/testing/useradm"
 
     def create_user(self, name, pwd, user_id=None, tenant_id=None):
-        args = [self.cmd,
-                'create-user',
-                '--username', name,
-                '--password', pwd]
+        args = [self.cmd, "create-user", "--username", name, "--password", pwd]
 
         if user_id is not None:
-            args.extend(['--user-id', user_id])
+            args.extend(["--user-id", user_id])
 
         if tenant_id is not None:
-            args.extend(['--tenant-id', tenant_id])
+            args.extend(["--tenant-id", tenant_id])
 
         subprocess.run(args, check=True)
 
     def set_password(self, name, pwd, tenant_id=None):
-        args = [self.cmd,
-                'set-password',
-                '--username', name,
-                '--password', pwd]
+        args = [
+            self.cmd,
+            "set-password",
+            "--username",
+            name,
+            "--password",
+            pwd,
+        ]
 
         if tenant_id is not None:
-            args.extend(['--tenant-id', tenant_id])
+            args.extend(["--tenant-id", tenant_id])
 
         subprocess.run(args, check=True)
 
     def migrate(self, tenant_id=None):
-        args = [self.cmd, 'migrate']
+        args = [self.cmd, "migrate"]
 
         if tenant_id:
-            args += ['--tenant', tenant_id]
+            args += ["--tenant", tenant_id]
 
         subprocess.run(args, check=True)

--- a/tests/tests/test_api_management.py
+++ b/tests/tests/test_api_management.py
@@ -12,17 +12,30 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
-from common import init_users, init_users_f, init_users_mt, init_users_mt_f, cli,api_client_mgmt, mongo, make_auth
 import bravado
+import json
 import pytest
 import tenantadm
 
+from base64 import b64decode
+from common import (
+    init_users,
+    init_users_f,
+    init_users_mt,
+    init_users_mt_f,
+    cli,
+    api_client_mgmt,
+    mongo,
+    make_auth,
+    user_tokens,
+)
+
+
 class TestManagementApiPostUsersBase:
     def _do_test_ok(self, api_client_mgmt, init_users, new_user, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
-
 
         _, r = api_client_mgmt.create_user(new_user, auth)
         assert r.status_code == 201
@@ -34,8 +47,10 @@ class TestManagementApiPostUsersBase:
         assert len(found_user) == 1
         found_user = found_user[0]
 
-    def _do_test_fail_duplicate_email(self, api_client_mgmt, init_users, new_user, tenant_id=None):
-        auth=None
+    def _do_test_fail_duplicate_email(
+        self, api_client_mgmt, init_users, new_user, tenant_id=None
+    ):
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
@@ -47,18 +62,18 @@ class TestManagementApiPostUsersBase:
 
 class TestManagementApiPostUsers(TestManagementApiPostUsersBase):
     def test_ok(self, api_client_mgmt, init_users):
-        new_user = {"email":"foo@bar.com", "password": "asdf1234zxcv"}
+        new_user = {"email": "foo@bar.com", "password": "asdf1234zxcv"}
         self._do_test_ok(api_client_mgmt, init_users, new_user)
 
     def test_fail_malformed_body(self, api_client_mgmt):
-        new_user = {"foo":"bar"}
+        new_user = {"foo": "bar"}
         try:
             api_client_mgmt.create_user(new_user)
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 400
 
     def test_fail_no_password(self, api_client_mgmt):
-        new_user = {"email":"foobar"}
+        new_user = {"email": "foobar"}
         try:
             api_client_mgmt.create_user(new_user)
         except bravado.exception.HTTPError as e:
@@ -72,40 +87,45 @@ class TestManagementApiPostUsers(TestManagementApiPostUsersBase):
             assert e.response.status_code == 400
 
     def test_fail_not_an_email(self, api_client_mgmt):
-        new_user = {"email":"foobar", "password": "asdf1234zxcv"}
+        new_user = {"email": "foobar", "password": "asdf1234zxcv"}
         try:
             api_client_mgmt.create_user(new_user)
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 400
 
     def test_fail_pwd_too_short(self, api_client_mgmt):
-        new_user = {"email":"foo@bar.com", "password": "asdf"}
+        new_user = {"email": "foo@bar.com", "password": "asdf"}
         try:
             api_client_mgmt.create_user(new_user)
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 422
 
     def test_fail_duplicate_email(self, api_client_mgmt, init_users):
-        new_user = {"email":"foo@bar.com", "password": "asdf"}
+        new_user = {"email": "foo@bar.com", "password": "asdf"}
         self._do_test_fail_duplicate_email(api_client_mgmt, init_users, new_user)
 
 
 class TestManagementApiPostUsersEnterprise(TestManagementApiPostUsersBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, tenant_id, api_client_mgmt, init_users_mt):
-        new_user = {"email":"foo@bar.com", "password": "asdf1234zxcv"}
+        new_user = {"email": "foo@bar.com", "password": "asdf1234zxcv"}
         with tenantadm.run_fake_create_user(new_user):
-            self._do_test_ok(api_client_mgmt, init_users_mt[tenant_id], new_user, tenant_id)
+            self._do_test_ok(
+                api_client_mgmt, init_users_mt[tenant_id], new_user, tenant_id
+            )
 
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_fail_duplicate_email(self, tenant_id, api_client_mgmt, init_users_mt):
-        new_user = {"email":"foo@bar.com", "password": "asdf1234zxcv"}
+        new_user = {"email": "foo@bar.com", "password": "asdf1234zxcv"}
         with tenantadm.run_fake_create_user(new_user, 422):
-            self._do_test_fail_duplicate_email(api_client_mgmt, init_users_mt[tenant_id], new_user, tenant_id)
+            self._do_test_fail_duplicate_email(
+                api_client_mgmt, init_users_mt[tenant_id], new_user, tenant_id
+            )
+
 
 class TestManagementApiGetUserBase:
     def _do_test_ok(self, api_client_mgmt, init_users, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
@@ -117,7 +137,7 @@ class TestManagementApiGetUserBase:
             assert found.updated_ts == u.updated_ts
 
     def _do_test_fail_not_found(self, api_client_mgmt, init_users, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
@@ -142,12 +162,14 @@ class TestManagementApiGetUserEnterprise(TestManagementApiGetUserBase):
 
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_fail_not_found(self, tenant_id, api_client_mgmt, init_users_mt):
-        self._do_test_fail_not_found(api_client_mgmt, init_users_mt[tenant_id], tenant_id)
+        self._do_test_fail_not_found(
+            api_client_mgmt, init_users_mt[tenant_id], tenant_id
+        )
 
 
 class TestManagementApiGetUsersBase:
     def _do_test_ok(self, api_client_mgmt, init_users, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
@@ -155,20 +177,23 @@ class TestManagementApiGetUsersBase:
         assert len(users) == len(init_users)
 
     def _do_test_no_users(self, api_client_mgmt, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
         users = api_client_mgmt.get_users(auth)
         assert len(users) == 0
 
+
 class TestManagementApiGetUsersOk(TestManagementApiGetUsersBase):
     def test_ok(self, api_client_mgmt, init_users):
         self._do_test_ok(api_client_mgmt, init_users)
 
+
 class TestManagementApiGetUsersNoUsers(TestManagementApiGetUsersBase):
     def test_no_users(self, api_client_mgmt):
         self._do_test_no_users(api_client_mgmt)
+
 
 class TestManagementApiGetUsersEnterprise(TestManagementApiGetUsersBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
@@ -182,25 +207,25 @@ class TestManagementApiGetUsersEnterprise(TestManagementApiGetUsersBase):
 
 class TestManagementApiDeleteUserBase:
     def _do_test_ok(self, api_client_mgmt, init_users, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
-        rsp = api_client_mgmt.delete_user(init_users[0]['id'], auth)
+        rsp = api_client_mgmt.delete_user(init_users[0]["id"], auth)
         assert rsp.status_code == 204
 
         users = api_client_mgmt.get_users(auth)
         assert len(users) == len(init_users) - 1
 
-        found = [u for u in users if u.id == init_users[0]['id']]
+        found = [u for u in users if u.id == init_users[0]["id"]]
         assert len(found) == 0
 
     def _do_test_not_found(self, api_client_mgmt, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
-        rsp = api_client_mgmt.delete_user('nonexistent_id', auth)
+        rsp = api_client_mgmt.delete_user("nonexistent_id", auth)
         assert rsp.status_code == 204
 
 
@@ -215,7 +240,9 @@ class TestManagementApiDeleteUser(TestManagementApiDeleteUserBase):
 class TestManagementApiDeleteUserEnterprise(TestManagementApiDeleteUserBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, tenant_id, api_client_mgmt, init_users_mt):
-        with tenantadm.run_fake_delete_user(tenant_id, init_users_mt[tenant_id][0]['id']):
+        with tenantadm.run_fake_delete_user(
+            tenant_id, init_users_mt[tenant_id][0]["id"]
+        ):
             self._do_test_ok(api_client_mgmt, init_users_mt[tenant_id], tenant_id)
 
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
@@ -225,7 +252,9 @@ class TestManagementApiDeleteUserEnterprise(TestManagementApiDeleteUserBase):
 
 
 class TestManagementApiPutUserBase:
-    def _do_test_ok_email(self, api_client_mgmt, init_users, user, update, tenant_id=None):
+    def _do_test_ok_email(
+        self, api_client_mgmt, init_users, user, update, tenant_id=None
+    ):
         auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
@@ -241,7 +270,9 @@ class TestManagementApiPutUserBase:
         found = [u for u in users if u.email == update["email"]]
         assert len(found) == 1
 
-    def _do_test_ok_email_or_pass(self, api_client_mgmt, init_users, user, update, tenant_id=None):
+    def _do_test_ok_email_or_pass(
+        self, api_client_mgmt, init_users, user, update, tenant_id=None
+    ):
         auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
@@ -268,7 +299,9 @@ class TestManagementApiPutUserBase:
 
         assert r.status_code == 200
 
-    def _do_test_fail_not_found(self, api_client_mgmt, init_users, update, tenant_id=None):
+    def _do_test_fail_not_found(
+        self, api_client_mgmt, init_users, update, tenant_id=None
+    ):
         auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
@@ -280,11 +313,13 @@ class TestManagementApiPutUserBase:
 
     def _do_test_fail_bad_update(self, api_client_mgmt, init_users, tenant_id=None):
         try:
-            _, r = api_client_mgmt.update_user(init_users[0].id, {"foo":"bar"})
+            _, r = api_client_mgmt.update_user(init_users[0].id, {"foo": "bar"})
         except bravado.exception.HTTPError as e:
             assert e.response.status_code == 400
 
-    def _do_test_fail_duplicate_email(self, api_client_mgmt, init_users, user, update, tenant_id=None):
+    def _do_test_fail_duplicate_email(
+        self, api_client_mgmt, init_users, user, update, tenant_id=None
+    ):
         auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
@@ -302,11 +337,18 @@ class TestManagementApiPutUser(TestManagementApiPutUserBase):
 
     def test_ok_pass(self, api_client_mgmt, init_users_f):
         update = {"password": "secretpassword123"}
-        self._do_test_ok_email_or_pass(api_client_mgmt, init_users_f, init_users_f[0], update)
+        self._do_test_ok_email_or_pass(
+            api_client_mgmt, init_users_f, init_users_f[0], update
+        )
 
     def test_ok_email_and_pass(self, api_client_mgmt, init_users_f):
-        update = {"email": "definitelyunique@foo.com", "password": "secretpassword123"}
-        self._do_test_ok_email_or_pass(api_client_mgmt, init_users_f, init_users_f[0], update)
+        update = {
+            "email": "definitelyunique@foo.com",
+            "password": "secretpassword123",
+        }
+        self._do_test_ok_email_or_pass(
+            api_client_mgmt, init_users_f, init_users_f[0], update
+        )
 
     def test_fail_not_found(self, api_client_mgmt, init_users_f):
         update = {"email": "foo@bar.com", "password": "secretpassword123"}
@@ -316,8 +358,13 @@ class TestManagementApiPutUser(TestManagementApiPutUserBase):
         self._do_test_fail_bad_update(api_client_mgmt, init_users_f)
 
     def test_fail_duplicate_email(self, api_client_mgmt, init_users_f):
-        update = {"email": init_users_f[1].email, "password": "secretpassword123"}
-        self._do_test_fail_duplicate_email(api_client_mgmt, init_users_f, init_users_f[0], update)
+        update = {
+            "email": init_users_f[1].email,
+            "password": "secretpassword123",
+        }
+        self._do_test_fail_duplicate_email(
+            api_client_mgmt, init_users_f, init_users_f[0], update
+        )
 
 
 class TestManagementApiPutUserEnterprise(TestManagementApiPutUserBase):
@@ -326,28 +373,39 @@ class TestManagementApiPutUserEnterprise(TestManagementApiPutUserBase):
         user = init_users_mt_f[tenant_id][0]
         update = {"email": "unique1@foo.com"}
         with tenantadm.run_fake_update_user(tenant_id, user.id, update):
-            self._do_test_ok_email(api_client_mgmt, init_users_mt_f[tenant_id], user, update, tenant_id)
+            self._do_test_ok_email(
+                api_client_mgmt, init_users_mt_f[tenant_id], user, update, tenant_id,
+            )
 
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok_pass(self, api_client_mgmt, init_users_mt_f, tenant_id):
         user = init_users_mt_f[tenant_id][1]
         with tenantadm.run_fake_get_tenants(tenant_id):
             update = {"password": "secretpassword123"}
-            self._do_test_ok_email_or_pass(api_client_mgmt, init_users_mt_f[tenant_id], user, update, tenant_id)
+            self._do_test_ok_email_or_pass(
+                api_client_mgmt, init_users_mt_f[tenant_id], user, update, tenant_id,
+            )
 
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok_email_and_pass(self, api_client_mgmt, init_users_mt_f, tenant_id):
         user = init_users_mt_f[tenant_id][2]
-        update = {"email": "definitelyunique@foo.com", "password": "secretpassword123"}
+        update = {
+            "email": "definitelyunique@foo.com",
+            "password": "secretpassword123",
+        }
         with tenantadm.run_fake_update_user(tenant_id, user.id, update):
-            self._do_test_ok_email_or_pass(api_client_mgmt, init_users_mt_f[tenant_id], user, update, tenant_id)
+            self._do_test_ok_email_or_pass(
+                api_client_mgmt, init_users_mt_f[tenant_id], user, update, tenant_id,
+            )
 
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_fail_not_found(self, api_client_mgmt, init_users_mt_f, tenant_id):
         user = init_users_mt_f[tenant_id][3]
         update = {"email": "foo@bar.com", "password": "secretpassword123"}
         with tenantadm.run_fake_update_user(tenant_id, user.id, update, 404):
-            self._do_test_fail_not_found(api_client_mgmt, init_users_mt_f[tenant_id], update, tenant_id)
+            self._do_test_fail_not_found(
+                api_client_mgmt, init_users_mt_f[tenant_id], update, tenant_id
+            )
 
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_fail_bad_update(self, api_client_mgmt, init_users_mt_f, tenant_id):
@@ -356,25 +414,32 @@ class TestManagementApiPutUserEnterprise(TestManagementApiPutUserBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_fail_duplicate_email(self, api_client_mgmt, init_users_mt_f, tenant_id):
         user = init_users_mt_f[tenant_id][0]
-        update = {"email": init_users_mt_f[tenant_id][1].email, "password": "secretpassword123"}
+        update = {
+            "email": init_users_mt_f[tenant_id][1].email,
+            "password": "secretpassword123",
+        }
         with tenantadm.run_fake_update_user(tenant_id, user.id, update, 422):
-            self._do_test_fail_duplicate_email(api_client_mgmt, init_users_mt_f[tenant_id], user, update, tenant_id)
+            self._do_test_fail_duplicate_email(
+                api_client_mgmt, init_users_mt_f[tenant_id], user, update, tenant_id,
+            )
 
 
 class TestManagementApiSettingsBase:
     def _do_test_ok(self, api_client_mgmt, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
         # nonempty
-        self._set_and_verify({"foo": "foo-val", "bar": "bar-val"}, api_client_mgmt, auth)
+        self._set_and_verify(
+            {"foo": "foo-val", "bar": "bar-val"}, api_client_mgmt, auth
+        )
 
         # empty
         self._set_and_verify({}, api_client_mgmt, auth)
 
     def _do_test_no_settings(self, api_client_mgmt, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
@@ -383,13 +448,13 @@ class TestManagementApiSettingsBase:
 
     def _set_and_verify(self, settings, api_client_mgmt, auth):
         r = api_client_mgmt.post_settings(settings, auth)
-        assert r.status_code==201
+        assert r.status_code == 201
 
         found = api_client_mgmt.get_settings(auth)
         assert found.json() == settings
 
     def _do_test_fail_bad_request(self, api_client_mgmt, tenant_id=None):
-        auth=None
+        auth = None
         if tenant_id is not None:
             auth = make_auth("foo", tenant_id)
 
@@ -409,6 +474,7 @@ class TestManagementApiSettings(TestManagementApiSettingsBase):
     def test_bad_request(self, api_client_mgmt):
         self._do_test_fail_bad_request(api_client_mgmt)
 
+
 class TestManagementApiSettingsEnterprise(TestManagementApiSettingsBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_ok(self, api_client_mgmt, init_users_mt_f, tenant_id):
@@ -417,3 +483,55 @@ class TestManagementApiSettingsEnterprise(TestManagementApiSettingsBase):
     @pytest.mark.parametrize("tenant_id", ["tenant1id", "tenant2id"])
     def test_bad_request(self, api_client_mgmt, tenant_id):
         self._do_test_fail_bad_request(api_client_mgmt, tenant_id)
+
+
+class TestManagementTokensBase:
+    def _test_get_delete_tokens(self, api_client_mgmt, user_tokens):
+        for utoken in user_tokens:
+            _, r = api_client_mgmt.create_api_token(auth=utoken)
+            assert r.status_code == 200
+            api_token = r.text
+            # Base64 decode the token payload/claims (ensure sufficient padding)
+            utoken_pld = json.loads(b64decode(utoken.split(".")[1] + "===").decode())
+            api_token_pld = json.loads(
+                b64decode(api_token.split(".")[1] + "===").decode()
+            )
+            # Assert payload is as expected
+            assert "exp" in utoken_pld
+            assert "exp" not in api_token_pld
+            assert utoken_pld["jti"] != api_token_pld["jti"]
+            assert utoken_pld["sub"] == api_token_pld["sub"]
+
+            _, r = api_client_mgmt.get_tokens(auth=api_token)
+            assert r.status_code == 200
+            tokens = json.loads(r.text)
+            assert api_token in tokens
+
+            # DELETE /tokens
+            _, r = api_client_mgmt.delete_api_token(auth=api_token)
+            assert r.status_code == 204
+
+            try:
+                api_client_mgmt.delete_api_token(auth=api_token)
+            except bravado.exception.HTTPError as e:
+                assert e.response.status_code == 401
+            try:
+                api_client_mgmt.delete_api_token(auth="foo.bar.baz")
+            except bravado.exception.HTTPError as e:
+                assert e.response.status_code == 500
+
+
+class TestManagementTokens(TestManagementTokensBase):
+    def test_get_delete_tokens(self, api_client_mgmt, cli):
+        users = [
+            {"name": "foo@bar.baz", "pwd": "correcthorse"},
+            {"name": "bob@bldr.org", "pwd": "correcthorse"},
+        ]
+        utokens = []
+        for user in users:
+            cli.create_user(**user)
+            _, r = api_client_mgmt.login(user["name"], user["pwd"])
+            assert r.status_code == 200, "Failed to setup test context"
+            utokens.append(r.text)
+
+        self._test_get_delete_tokens(api_client_mgmt, utokens)

--- a/user/mocks/App.go
+++ b/user/mocks/App.go
@@ -65,6 +65,39 @@ func (_m *App) CreateUserInternal(ctx context.Context, u *model.UserInternal) er
 	return r0
 }
 
+func (_m *App) CreateAPIToken(
+	ctx context.Context, rawToken string,
+) (*jwt.Token, error) {
+	ret := _m.Called(ctx, rawToken)
+
+	var r0 *jwt.Token
+	if rf, ok := ret.Get(0).(func(context.Context, string) *jwt.Token); ok {
+		r0 = rf(ctx, rawToken)
+	} else {
+		r0 = ret.Get(0).(*jwt.Token)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, rawToken)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+func (_m *App) DeleteAPIToken(ctx context.Context, rawToken string) error {
+	ret := _m.Called(ctx, rawToken)
+
+	var r0 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, rawToken)
+	} else {
+		r0 = ret.Error(1)
+	}
+	return r0
+}
+
 // DeleteTokens provides a mock function with given fields: ctx, tenantId, userId
 func (_m *App) DeleteTokens(ctx context.Context, tenantId string, userId string) error {
 	ret := _m.Called(ctx, tenantId, userId)

--- a/user/mocks/App.go
+++ b/user/mocks/App.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2020 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -96,6 +96,29 @@ func (_m *App) DeleteAPIToken(ctx context.Context, rawToken string) error {
 		r0 = ret.Error(1)
 	}
 	return r0
+}
+
+func (_m *App) GetActiveUserTokens(
+	ctx context.Context,
+	rawToken string,
+) ([]string, error) {
+	ret := _m.Called(ctx, rawToken)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(context.Context, string) []string); ok {
+		r0 = rf(ctx, rawToken)
+	} else {
+		r0 = ret.Get(0).([]string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, rawToken)
+	} else {
+		r1 = ret.Error(0)
+	}
+
+	return r0, r1
 }
 
 // DeleteTokens provides a mock function with given fields: ctx, tenantId, userId


### PR DESCRIPTION
Implements a fully user controlled JWT token management API:
GET /tokens - list all valid tokens for the users
POST /tokens - creates a new (permanent) management API token
DELETE /tokens - invalidates/deletes the token contained in the request header
Though this is just a PoC I have a couple of improvements in mind if we decide to move forward with this:
- Being able to specify token expiry time on POST /tokens requests
- Parameter for limiting the api scope for the generated token on POST /tokens
- Enable paging for GET /tokens endpoint