### PR TITLE
API spec fixes: schema and hostname

### DIFF
--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -6,7 +6,7 @@ info:
     An API for user administration and user authentication handling. Not exposed via the API Gateway - intended for internal use only.
 
 basePath: '/api/internal/v1/useradm'
-host: 'mender-device-auth:8080'
+host: 'mender-useradm:8080'
 schemes:
   - http
 

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -7,7 +7,7 @@ info:
     All responses from the API will contain 'X-MEN-RequestID' header with server-side generated request ID.
 
 basePath: '/api/management/v1/useradm'
-host: 'docker.mender.io'
+host: 'hosted.mender.io'
 schemes:
   - https
 


### PR DESCRIPTION
* [API spec] Consistently use host hosted.mender.io across all repos
* [API spec] Consistently use https schemes across all repos