### PR TITLE
api: New internal endpoint for getting user info

### DIFF
--- a/api/http/api_useradm_test.go
+++ b/api/http/api_useradm_test.go
@@ -14,11 +14,13 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 

--- a/api/http/api_useradm_test.go
+++ b/api/http/api_useradm_test.go
@@ -14,12 +14,12 @@
 package http
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -833,9 +833,11 @@ func TestUserAdmApiGetUsers(t *testing.T) {
 		uaUsers []model.User
 		uaError error
 
-		checker mt.ResponseChecker
+		queryString string
+		checker     mt.ResponseChecker
 	}{
 		"ok": {
+			queryString: "id=1&id=2",
 			uaUsers: []model.User{
 				{
 					ID:    "1",
@@ -877,6 +879,34 @@ func TestUserAdmApiGetUsers(t *testing.T) {
 				[]model.User{},
 			),
 		},
+		"error: invalid query string": {
+			queryString: "%%%%",
+
+			uaUsers: nil,
+			uaError: nil,
+
+			checker: mt.NewJSONResponse(
+				http.StatusBadRequest,
+				nil,
+				restError(`api: bad form parameters: `+
+					`invalid URL escape "%%%"`),
+			),
+		},
+		"error: bad query values": {
+			queryString: "created_before=an_hour_ago",
+
+			uaUsers: nil,
+			uaError: nil,
+
+			checker: mt.NewJSONResponse(
+				http.StatusBadRequest,
+				nil,
+				restError(`api: invalid form values: invalid `+
+					`form parameter "created_before": `+
+					`strconv.ParseInt: parsing `+
+					`"an_hour_ago": invalid syntax`),
+			),
+		},
 		"error: useradm internal": {
 			uaUsers: nil,
 			uaError: errors.New("some internal error"),
@@ -896,16 +926,159 @@ func TestUserAdmApiGetUsers(t *testing.T) {
 
 			//make mock useradm
 			uadm := &museradm.App{}
-			uadm.On("GetUsers", ctx).Return(tc.uaUsers, tc.uaError)
+			defer uadm.AssertExpectations(t)
+
+			if tc.uaUsers != nil || tc.uaError != nil {
+				fltr := model.UserFilter{}
+				query, _ := url.ParseQuery(tc.queryString)
+				fltr.ParseForm(query)
+				uadm.On("GetUsers", ctx, fltr).
+					Return(tc.uaUsers, tc.uaError)
+			}
 
 			//make handler
 			api := makeMockApiHandler(t, uadm, nil)
 
 			//make request
 			req := makeReq("GET",
-				"http://1.2.3.4/api/management/v1/useradm/users",
+				"http://1.2.3.4"+uriManagementUsers+"?"+
+					tc.queryString,
 				"Bearer "+token,
 				nil)
+
+			//test
+			recorded := test.RunRequest(t, api, req)
+			mt.CheckResponse(t, tc.checker, recorded)
+		})
+	}
+}
+
+func TestUserAdmApiTenantsGetUsers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	testCases := map[string]struct {
+		tenant string
+
+		queryString string
+		uaUsers     []model.User
+		uaError     error
+
+		checker mt.ResponseChecker
+	}{
+		"ok": {
+			queryString: "id=1&id=2",
+			uaUsers: []model.User{
+				{
+					ID:    "1",
+					Email: "foo@acme.com",
+				},
+				{
+					ID:        "2",
+					Email:     "bar@acme.com",
+					CreatedTs: &now,
+					UpdatedTs: &now,
+				},
+			},
+			uaError: nil,
+
+			checker: mt.NewJSONResponse(
+				http.StatusOK,
+				nil,
+				[]model.User{
+					{
+						ID:    "1",
+						Email: "foo@acme.com",
+					},
+					{
+						ID:        "2",
+						Email:     "bar@acme.com",
+						CreatedTs: &now,
+						UpdatedTs: &now,
+					},
+				},
+			),
+		},
+		"ok: empty": {
+			uaUsers: []model.User{},
+			uaError: nil,
+
+			checker: mt.NewJSONResponse(
+				http.StatusOK,
+				nil,
+				[]model.User{},
+			),
+		},
+		"error: invalid query string": {
+			queryString: "%%%%",
+
+			uaUsers: nil,
+			uaError: nil,
+
+			checker: mt.NewJSONResponse(
+				http.StatusBadRequest,
+				nil,
+				restError(`api: bad form parameters: `+
+					`invalid URL escape "%%%"`),
+			),
+		},
+		"error: bad query values": {
+			queryString: "created_before=an_hour_ago",
+
+			uaUsers: nil,
+			uaError: nil,
+
+			checker: mt.NewJSONResponse(
+				http.StatusBadRequest,
+				nil,
+				restError(`api: invalid form values: invalid `+
+					`form parameter "created_before": `+
+					`strconv.ParseInt: parsing `+
+					`"an_hour_ago": invalid syntax`),
+			),
+		},
+		"error: useradm internal": {
+			uaUsers: nil,
+			uaError: errors.New("some internal error"),
+
+			checker: mt.NewJSONResponse(
+				http.StatusInternalServerError,
+				nil,
+				restError("internal error"),
+			),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(fmt.Sprintf("tc %s", name), func(t *testing.T) {
+
+			ctx := mtesting.ContextMatcher()
+
+			//make mock useradm
+			uadm := &museradm.App{}
+			defer uadm.AssertExpectations(t)
+
+			if tc.uaUsers != nil || tc.uaError != nil {
+				fltr := model.UserFilter{}
+				query, _ := url.ParseQuery(tc.queryString)
+				fltr.ParseForm(query)
+				uadm.On("GetUsers", ctx, fltr).
+					Return(tc.uaUsers, tc.uaError)
+			}
+
+			//make handler
+			api := makeMockApiHandler(t, uadm, nil)
+
+			//make request
+			repl := strings.NewReplacer(":id", tc.tenant)
+			req, _ := http.NewRequest(
+				"GET",
+				"http://localhost"+
+					repl.Replace(uriInternalTenantUsers),
+				nil,
+			)
+			req.Header.Set("X-MEN-RequestID", "test")
+			req.URL.RawQuery = tc.queryString
 
 			//test
 			recorded := test.RunRequest(t, api, req)

--- a/docs/internal_api.yml
+++ b/docs/internal_api.yml
@@ -173,6 +173,75 @@ paths:
           description: Internal server error.
           schema:
             $ref: "#/definitions/Error"
+
+    get:
+      operationId: List Users
+      tags:
+        - Internal API
+      summary: |
+        List all users registered under the tenant owning the JWT.
+      parameters:
+        - name: tenant_id
+          in: path
+          type: string
+          description: Tenant ID.
+          required: true
+        - name: id
+          in: query
+          type: string
+          description: >
+            Limit result by user ID, can be repeated to include multiple users
+            in the query.
+          required: false
+        - name: email
+          in: query
+          type: string
+          description: >
+            Limit result by user email, can be repeated to include multiple users
+            in the query.
+          required: false
+        - name: created_after
+          in: query
+          type: integer
+          description: >
+            Filter users created after timestamp (UNIX timestamp).
+          required: false
+        - name: created_before
+          in: query
+          type: integer
+          description: >
+            Filter users created before timestamp (UNIX timestamp).
+          required: false
+        - name: updated_after
+          in: query
+          type: integer
+          description: >
+            Filter users updated after timestamp (UNIX timestamp).
+          required: false
+        - name: updated_before
+          in: query
+          type: integer
+          description: >
+            Filter users updated before timestamp (UNIX timestamp).
+          required: false
+      responses:
+        200:
+          description: Successful response.
+          schema:
+            title: ListOfUsers
+            type: array
+            items:
+              $ref: '#/definitions/User'
+        401:
+          description: |
+                The user cannot be granted authentication.
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: Internal server error.
+          schema:
+            $ref: "#/definitions/Error"
+
   /tokens:
     delete:
       operationId: Revoke User Tokens
@@ -226,6 +295,36 @@ definitions:
         type: string
     example:
       tenant_id: "1234"
+
+  User:
+    description: User descriptor.
+    type: object
+    properties:
+      email:
+        description: A unique email address.
+        type: string
+      id:
+        description: User Id.
+        type: string
+      created_ts:
+        description: |
+            Server-side timestamp of the user creation.
+        type: string
+        format: date-time
+      updated_ts:
+        description: |
+            Server-side timestamp of the last user information update.
+        type: string
+        format: date-time
+    required:
+      - email
+      - id
+    example:
+      email: "user@acme.com"
+      id: "806603def19d417d004a4b67e"
+      created_ts: "2020-07-06T15:04:49.114046203+02:00"
+      updated_ts: "2020-07-07T01:04:49.114046203+02:00"
+
   UserNew:
     description: New user descriptor.
     type: object

--- a/docs/management_api.yml
+++ b/docs/management_api.yml
@@ -78,6 +78,45 @@ paths:
         - ManagementJWT: []
       summary: |
         List all users registered under the tenant owning the JWT.
+      parameters:
+        - name: id
+          in: query
+          type: string
+          description: >
+            Limit result by user ID, can be repeated to include multiple users
+            in the query.
+          required: false
+        - name: email
+          in: query
+          type: string
+          description: >
+            Limit result by user email, can be repeated to include multiple users
+            in the query.
+          required: false
+        - name: created_after
+          in: query
+          type: integer
+          description: >
+            Filter users created after timestamp (UNIX timestamp).
+          required: false
+        - name: created_before
+          in: query
+          type: integer
+          description: >
+            Filter users created before timestamp (UNIX timestamp).
+          required: false
+        - name: updated_after
+          in: query
+          type: integer
+          description: >
+            Filter users updated after timestamp (UNIX timestamp).
+          required: false
+        - name: updated_before
+          in: query
+          type: integer
+          description: >
+            Filter users updated before timestamp (UNIX timestamp).
+          required: false
       responses:
         200:
           description: Successful response.
@@ -95,6 +134,7 @@ paths:
           description: Internal server error.
           schema:
             $ref: "#/definitions/Error"
+
     post:
       operationId: Create User
       tags:

--- a/model/user.go
+++ b/model/user.go
@@ -15,6 +15,8 @@
 package model
 
 import (
+	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -148,5 +150,65 @@ func checkPwd(password string) error {
 }
 
 func checkEmail(email string) error {
+	return nil
+}
+
+type UserFilter struct {
+	ID    []string `json:"id,omitempty"`
+	Email []string `json:"email,omitempty"`
+
+	CreatedAfter  *time.Time `json:"created_after,omitempty"`
+	CreatedBefore *time.Time `json:"created_before,omitempty"`
+
+	UpdatedAfter  *time.Time `json:"updated_after,omitempty"`
+	UpdatedBefore *time.Time `json:"updated_before,omitempty"`
+}
+
+func (fltr *UserFilter) ParseForm(form url.Values) error {
+	if ids, ok := form["id"]; ok {
+		fltr.ID = ids
+	}
+	if email, ok := form["email"]; ok {
+		fltr.Email = email
+	}
+	if ca := form.Get("created_after"); ca != "" {
+		caInt, err := strconv.ParseInt(ca, 10, 64)
+		if err != nil {
+			return errors.Wrap(err,
+				`invalid form parameter "created_after"`)
+		}
+		caUnix := time.Unix(caInt, 0)
+		fltr.CreatedAfter = &caUnix
+	}
+
+	if cb := form.Get("created_before"); cb != "" {
+		cbInt, err := strconv.ParseInt(cb, 10, 64)
+		if err != nil {
+			return errors.Wrap(err,
+				`invalid form parameter "created_before"`)
+		}
+		cbUnix := time.Unix(cbInt, 0)
+		fltr.CreatedBefore = &cbUnix
+	}
+
+	if ua := form.Get("updated_after"); ua != "" {
+		uaInt, err := strconv.ParseInt(ua, 10, 64)
+		if err != nil {
+			return errors.Wrap(err,
+				`invalid form parameter "updated_after"`)
+		}
+		uaUnix := time.Unix(uaInt, 0)
+		fltr.UpdatedAfter = &uaUnix
+	}
+
+	if ub := form.Get("updated_before"); ub != "" {
+		ubInt, err := strconv.ParseInt(ub, 10, 64)
+		if err != nil {
+			return errors.Wrap(err,
+				`invalid form parameter "updated_before"`)
+		}
+		ubUnix := time.Unix(ubInt, 0)
+		fltr.UpdatedBefore = &ubUnix
+	}
 	return nil
 }

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -43,7 +43,7 @@ type DataStore interface {
 	//GetUserByEmail returns nil,nil if not found
 	GetUserByEmail(ctx context.Context, email string) (*model.User, error)
 	GetUserById(ctx context.Context, id string) (*model.User, error)
-	GetUsers(ctx context.Context) ([]model.User, error)
+	GetUsers(ctx context.Context, fltr model.UserFilter) ([]model.User, error)
 	DeleteUser(ctx context.Context, id string) error
 	SaveToken(ctx context.Context, token *jwt.Token) error
 	GetTokenById(ctx context.Context, id oid.ObjectID) (*jwt.Token, error)

--- a/store/mocks/DataStore.go
+++ b/store/mocks/DataStore.go
@@ -180,13 +180,13 @@ func (_m *DataStore) GetUserById(ctx context.Context, id string) (*model.User, e
 	return r0, r1
 }
 
-// GetUsers provides a mock function with given fields: ctx
-func (_m *DataStore) GetUsers(ctx context.Context) ([]model.User, error) {
-	ret := _m.Called(ctx)
+// GetUsers provides a mock function with given fields: ctx, fltr
+func (_m *DataStore) GetUsers(ctx context.Context, fltr model.UserFilter) ([]model.User, error) {
+	ret := _m.Called(ctx, fltr)
 
 	var r0 []model.User
-	if rf, ok := ret.Get(0).(func(context.Context) []model.User); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, model.UserFilter) []model.User); ok {
+		r0 = rf(ctx, fltr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.User)
@@ -194,8 +194,8 @@ func (_m *DataStore) GetUsers(ctx context.Context) ([]model.User, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, model.UserFilter) error); ok {
+		r1 = rf(ctx, fltr)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/user/mocks/App.go
+++ b/user/mocks/App.go
@@ -123,13 +123,13 @@ func (_m *App) GetUser(ctx context.Context, id string) (*model.User, error) {
 	return r0, r1
 }
 
-// GetUsers provides a mock function with given fields: ctx
-func (_m *App) GetUsers(ctx context.Context) ([]model.User, error) {
-	ret := _m.Called(ctx)
+// GetUsers provides a mock function with given fields: ctx, fltr
+func (_m *App) GetUsers(ctx context.Context, fltr model.UserFilter) ([]model.User, error) {
+	ret := _m.Called(ctx, fltr)
 
 	var r0 []model.User
-	if rf, ok := ret.Get(0).(func(context.Context) []model.User); ok {
-		r0 = rf(ctx)
+	if rf, ok := ret.Get(0).(func(context.Context, model.UserFilter) []model.User); ok {
+		r0 = rf(ctx, fltr)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.User)
@@ -137,8 +137,8 @@ func (_m *App) GetUsers(ctx context.Context) ([]model.User, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
+	if rf, ok := ret.Get(1).(func(context.Context, model.UserFilter) error); ok {
+		r1 = rf(ctx, fltr)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/user/useradm.go
+++ b/user/useradm.go
@@ -54,7 +54,7 @@ type App interface {
 	CreateUserInternal(ctx context.Context, u *model.UserInternal) error
 	UpdateUser(ctx context.Context, id string, u *model.UserUpdate) error
 	Verify(ctx context.Context, token *jwt.Token) error
-	GetUsers(ctx context.Context) ([]model.User, error)
+	GetUsers(ctx context.Context, fltr model.UserFilter) ([]model.User, error)
 	GetUser(ctx context.Context, id string) (*model.User, error)
 	DeleteUser(ctx context.Context, id string) error
 	SetPassword(ctx context.Context, u model.UserUpdate) error
@@ -372,8 +372,8 @@ func (ua *UserAdm) Verify(ctx context.Context, token *jwt.Token) error {
 	return nil
 }
 
-func (ua *UserAdm) GetUsers(ctx context.Context) ([]model.User, error) {
-	users, err := ua.db.GetUsers(ctx)
+func (ua *UserAdm) GetUsers(ctx context.Context, fltr model.UserFilter) ([]model.User, error) {
+	users, err := ua.db.GetUsers(ctx, fltr)
 	if err != nil {
 		return nil, errors.Wrap(err, "useradm: failed to get users")
 	}

--- a/user/useradm_test.go
+++ b/user/useradm_test.go
@@ -929,11 +929,12 @@ func TestUserAdmGetUsers(t *testing.T) {
 			ctx := context.Background()
 
 			db := &mstore.DataStore{}
-			db.On("GetUsers", ctx).Return(tc.dbUsers, tc.dbErr)
+			db.On("GetUsers", ctx, model.UserFilter{}).
+				Return(tc.dbUsers, tc.dbErr)
 
 			useradm := NewUserAdm(nil, db, nil, Config{})
 
-			users, err := useradm.GetUsers(ctx)
+			users, err := useradm.GetUsers(ctx, model.UserFilter{})
 
 			if tc.err != nil {
 				assert.EqualError(t, err, tc.err.Error())


### PR DESCRIPTION
Updated endpoint `POST /api/(management|internal)/v1/useradm/tenants/:id/users` with an `id` parameter to filter by user `id`s (needed by MEN-3749/3750).