### PR TITLE
store: Update user returns old document instead of new

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -205,7 +205,7 @@ func (db *DataStoreMongo) UpdateUser(
 	f := bson.M{"_id": id}
 	up := bson.M{"$set": u}
 	fuOpts := mopts.FindOneAndUpdate().
-		SetReturnDocument(mopts.After)
+		SetReturnDocument(mopts.Before)
 	err := collUsers.FindOneAndUpdate(ctx, f, up, fuOpts).
 		Decode(updatedUser)
 


### PR DESCRIPTION
This is a noop for the open-source repository, but required for the enterprise version (related to MEN-4041).