### PR TITLE
store/mongo: Fix migration_1_4_0

### DIFF
--- a/store/mongo/migration_1_1_4.go
+++ b/store/mongo/migration_1_1_4.go
@@ -22,6 +22,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	mopts "go.mongodb.org/mongo-driver/mongo/options"
+	mongox "go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
 const (
@@ -32,6 +33,8 @@ type migration_1_1_4 struct {
 	ds  *DataStoreMongo
 	ctx context.Context
 }
+
+const ErrCodeIndexOptionsError = 85
 
 func (m *migration_1_1_4) Up(from migrate.Version) error {
 	c := m.ds.client.Database(mstore.DbFromContext(m.ctx, DbName)).
@@ -52,16 +55,18 @@ func (m *migration_1_1_4) Up(from migrate.Version) error {
 
 	_, err := idxUsers.CreateOne(m.ctx, uniqueEmailIndex)
 	if err != nil {
-		return err
+		if mgoErr, ok := err.(mongox.Error); ok {
+			if mgoErr.Code == ErrCodeIndexOptionsError {
+				_, e := idxUsers.DropOne(m.ctx, OldDbUniqueEmailIndexName)
+				if e != nil {
+					return err
+				}
+				_, err = idxUsers.CreateOne(m.ctx, uniqueEmailIndex)
+			}
+		}
 	}
 
-	// drop old index
-	_, err = idxUsers.DropOne(m.ctx, OldDbUniqueEmailIndexName)
-	if err != nil && err.Error() != "(IndexNotFound) index not found with name [uniqueEmail]" {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (m *migration_1_1_4) Version() migrate.Version {

--- a/store/mongo/migration_1_1_4.go
+++ b/store/mongo/migration_1_1_4.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/mendersoftware/go-lib-micro/mongo/migrate"
 	mstore "github.com/mendersoftware/go-lib-micro/store"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	mopts "go.mongodb.org/mongo-driver/mongo/options"
@@ -59,7 +60,7 @@ func (m *migration_1_1_4) Up(from migrate.Version) error {
 			if mgoErr.Code == ErrCodeIndexOptionsError {
 				_, e := idxUsers.DropOne(m.ctx, OldDbUniqueEmailIndexName)
 				if e != nil {
-					return err
+					return errors.Wrap(err, e.Error())
 				}
 				_, err = idxUsers.CreateOne(m.ctx, uniqueEmailIndex)
 			}


### PR DESCRIPTION
The migration fails if index with name `uniqueName` exists.