### PR TITLE
Remove the gzip middleware

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -58,9 +58,6 @@ var (
 	defaultProdStack = []rest.Middleware{
 		// catches the panic errors
 		&rest.RecoverMiddleware{},
-
-		// response compression
-		&rest.GzipMiddleware{},
 	}
 
 	commonStack = []rest.Middleware{


### PR DESCRIPTION
We delegate the response compression to the API gateway. For this
reason, we don't want to enable the gzip middleware directly in the
service.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>