### PR TITLE
tests: add prefix /usr/bin to the CliClient command

### DIFF
--- a/tests/tests/client.py
+++ b/tests/tests/client.py
@@ -171,7 +171,7 @@ class ManagementApiClient(ApiClient):
 
 
 class CliClient:
-    cmd = "useradm"
+    cmd = "/usr/bin/useradm"
 
     def __init__(self):
         self.client = docker.from_env()


### PR DESCRIPTION
To align it with the rest of the repositories.