### PR TITLE
fix: replace colon with hash for path params modifiers in URLs

### DIFF
--- a/api/http/api_useradm.go
+++ b/api/http/api_useradm.go
@@ -35,7 +35,7 @@ import (
 const (
 	uriManagementAuthLogin  = "/api/management/v1/useradm/auth/login"
 	uriManagementAuthLogout = "/api/management/v1/useradm/auth/logout"
-	uriManagementUser       = "/api/management/v1/useradm/users/:id"
+	uriManagementUser       = "/api/management/v1/useradm/users/#id"
 	uriManagementUsers      = "/api/management/v1/useradm/users"
 	uriManagementSettings   = "/api/management/v1/useradm/settings"
 
@@ -44,8 +44,8 @@ const (
 
 	uriInternalAuthVerify  = "/api/internal/v1/useradm/auth/verify"
 	uriInternalTenants     = "/api/internal/v1/useradm/tenants"
-	uriInternalTenantUsers = "/api/internal/v1/useradm/tenants/:id/users"
-	uriInternalTenantUser  = "/api/internal/v1/useradm/tenants/:id/users/:userid"
+	uriInternalTenantUsers = "/api/internal/v1/useradm/tenants/#id/users"
+	uriInternalTenantUser  = "/api/internal/v1/useradm/tenants/#id/users/#userid"
 	uriInternalTokens      = "/api/internal/v1/useradm/tokens"
 )
 

--- a/api/http/api_useradm_test.go
+++ b/api/http/api_useradm_test.go
@@ -1180,7 +1180,7 @@ func TestUserAdmApiTenantsGetUsers(t *testing.T) {
 			api := makeMockApiHandler(t, uadm, nil)
 
 			//make request
-			repl := strings.NewReplacer(":id", tc.tenant)
+			repl := strings.NewReplacer("#id", tc.tenant)
 			req, _ := http.NewRequest(
 				"GET",
 				"http://localhost"+

--- a/client/tenant/client_tenantadm.go
+++ b/client/tenant/client_tenantadm.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ const (
 	UriBase         = "/api/internal/v1/tenantadm"
 	GetTenantsUri   = UriBase + "/tenants"
 	UsersUri        = UriBase + "/users"
-	TenantsUsersUri = UriBase + "/tenants/:tid/users/:uid"
+	TenantsUsersUri = UriBase + "/tenants/#tid/users/#uid"
 	URIHealth       = UriBase + "/health"
 	// default request timeout, 10s
 	defaultReqTimeout = time.Duration(10) * time.Second
@@ -239,7 +239,7 @@ func (c *Client) UpdateUser(
 
 	reader := bytes.NewReader(json)
 
-	repl := strings.NewReplacer(":tid", tenantId, ":uid", userId)
+	repl := strings.NewReplacer("#tid", tenantId, "#uid", userId)
 	uri := repl.Replace(TenantsUsersUri)
 
 	req, err := http.NewRequest(http.MethodPut,
@@ -283,7 +283,7 @@ func (c *Client) DeleteUser(
 	client apiclient.HttpRunner,
 ) error {
 
-	repl := strings.NewReplacer(":tid", tenantId, ":uid", userId)
+	repl := strings.NewReplacer("#tid", tenantId, "#uid", userId)
 	uri := repl.Replace(TenantsUsersUri)
 
 	req, err := http.NewRequest(http.MethodDelete,

--- a/client/tenant/client_tenantadm_test.go
+++ b/client/tenant/client_tenantadm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2022 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -288,8 +288,8 @@ func TestDeleteUser(t *testing.T) {
 				assert.EqualError(t, err, tc.err.Error())
 			} else {
 				assert.NoError(t, err)
-				uri := strings.Replace(TenantsUsersUri, ":tid", "foo", 1)
-				uri = strings.Replace(uri, ":uid", "bar", 1)
+				uri := strings.Replace(TenantsUsersUri, "#tid", "foo", 1)
+				uri = strings.Replace(uri, "#uid", "bar", 1)
 				assert.Equal(t, uri, rd.Url.Path)
 				assert.Equal(t, "DELETE", rd.Method)
 			}
@@ -351,8 +351,8 @@ func TestUpdateUser(t *testing.T) {
 			err := c.UpdateUser(context.Background(), tc.tid, tc.uid, up, &apiclient.HttpApi{})
 
 			assert.Equal(t, "PUT", rd.Method)
-			uri := strings.Replace(TenantsUsersUri, ":tid", tc.tid, 1)
-			uri = strings.Replace(uri, ":uid", tc.uid, 1)
+			uri := strings.Replace(TenantsUsersUri, "#tid", tc.tid, 1)
+			uri = strings.Replace(uri, "#uid", tc.uid, 1)
 			assert.Equal(t, uri, rd.Url.Path)
 
 			if tc.err != nil {

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2022 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
 
 # tests are supposed to be located in the same directory as this file
 


### PR DESCRIPTION
Changelog: Title
Ticket: MEN-5713
Signed-off-by: Peter Grzybowski <peter@northern.tech>
(cherry picked from commit 097936aa0e00671f3aed11937e67b74c970a2c0f)