### PR TITLE
chore(cleanup): Do not expose "ETagUpdate" to update endpoint

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -182,7 +182,7 @@ type UserUpdate struct {
 
 	// ETagUpdate sets the updated ETag value. If not set, it is incremented from the
 	// ETag field if that field is set.
-	ETagUpdate *ETag `bson:"etag,omitempty"`
+	ETagUpdate *ETag `json:"-" bson:"etag,omitempty"`
 
 	// user email address
 	Email Email `json:"email,omitempty" bson:",omitempty" valid:"email"`


### PR DESCRIPTION
Etags are not exposed to the v1 API and should be set using headers (RFC7232).