### PR TITLE
fix: Make user updates default to skip ETag checks (wildcard match)

### DIFF
--- a/store/mongo/datastore_mongo_test.go
+++ b/store/mongo/datastore_mongo_test.go
@@ -191,7 +191,7 @@ func TestMongoUpdateUser(t *testing.T) {
 			ID:       "2bbde4d1-2a4c-47dc-9df4-f048285d2704",
 			Email:    "baz+mcetagface@bar.com",
 			Password: "pretenditsahash",
-			ETag:     new(model.ETag),
+			ETag:     &model.ETag{1},
 		},
 	}
 
@@ -234,10 +234,10 @@ func TestMongoUpdateUser(t *testing.T) {
 		},
 		"ok with tenant and etag": {
 			inUserUpdate: model.UserUpdate{
-				ETag:       new(model.ETag),
+				ETag:       &model.ETag{1},
 				Email:      "baz@bar.com",
 				Password:   "correcthorsebatterystaple",
-				ETagUpdate: &model.ETag{1},
+				ETagUpdate: &model.ETag{2},
 			},
 			inUserId: "2bbde4d1-2a4c-47dc-9df4-f048285d2704",
 			tenant:   "foo",

--- a/user/useradm.go
+++ b/user/useradm.go
@@ -398,6 +398,10 @@ func (ua *UserAdm) UpdateUser(ctx context.Context, id string, userUpdate *model.
 		next := user.NextETag()
 		userUpdate.ETagUpdate = &next
 		userUpdate.ETag = user.ETag
+		if user.ETag == nil {
+			// If the ETag field is not set, assign the etag to nil
+			user.ETag = &model.ETagNil
+		}
 	} else if user.ETag == nil || *userUpdate.ETag != *user.ETag {
 		return ErrETagMismatch
 	}


### PR DESCRIPTION
This commit restores the old behavior by default.