### PR TITLE
chore(docker): Add -trimpath to go build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN echo "nobody:x:65534:65534:Nobody:/:" > /etc_extra/passwd
 RUN chown -R nobody:nobody /etc_extra
 RUN apk add --no-cache ca-certificates
 COPY ./ .
-RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o useradm .
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -trimpath -o useradm .
 
 
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN echo "nobody:x:65534:65534:Nobody:/:" > /etc_extra/passwd
 RUN chown -R nobody:nobody /etc_extra
 RUN apk add --no-cache ca-certificates
 COPY ./ .
-RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -trimpath -o useradm .
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOARCH=$TARGETARCH go build -trimpath -o useradm .
 
 
 FROM scratch

--- a/Dockerfile.acceptance-testing
+++ b/Dockerfile.acceptance-testing
@@ -7,7 +7,9 @@ RUN echo "nobody:x:65534:65534:Nobody:/:" > /etc_extra/passwd
 RUN chown -R nobody:nobody /etc_extra
 RUN mkdir /tmp/gocovedir
 COPY ./ .
-RUN env CGO_ENABLED=0 go test -c -o useradm \
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/root/.cache/go-build \
+    env CGO_ENABLED=0 go test -c -o useradm \
     -tags main -cover -covermode=atomic \
     -coverpkg $(go list ./... | grep -v vendor | grep -v mock | grep -v test | tr  '\n' ,)
 


### PR DESCRIPTION
Removes build host specific paths from traces.